### PR TITLE
New comparison interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,49 @@ Multi-model comaprison report
 -----------------------------
 
 Once several models have been analysed using the time series analysis,
-their time development can be compared using the analysis_compare command.
-This is currently hardwired, but work in on-going.
+their time development can be compared using the analysis_compare command:
+```
+analysis_compare recipe.yml
+```
+
+The comparison reports are generated from a user defined yaml recipe.
+
+In this yml file, the key structure is:
+```
+name: <Analysis name>
+do_analysis_timeseries: <bool>
+jobs:
+   <jobID1>:
+      description: <descrption of the first job>
+   <jobID2>:
+      description: <descrption of the second job>      
+```
+Where the `name` is the name of script and the ultimately the path of the
+comparison report.
+
+The `do_analysis_timeseries` bool lets analysis_compare send jobs to 
+`analysis_timeseries`, allowing the user to run the entire suite in one 
+command, instead of individually running the `analysis_timeseries` then
+the `analysis_compare` part afterwards.
+
+The `jobs` is a dict of job IDs, that describe how each job will appear in the 
+final report. 
+
+The optional arguments for each job are:
+    - colour: a colour hex, or html recognised string (default is a randomly generated hex colour.)
+    - thickness: line thickness for matplotlib (default (`0.7`)
+    - linestyle: line style for matplotlib (default: `'-'`)
+    - suite: suite to send to `analysis_timeseries` if `do_analysis_timeseries` is true.
+    
+A sample yaml exists in `input_yml/comparison_analysis_template.yml`,
+which can be adapted to additional analysis. 
+
+
+
+
+
+
+
 
 Documentation
 =============

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The comparison reports are generated from a user defined yaml recipe.
 
 In this yml file, the key structure is:
 ```
-name: <Analysis name>
+name: <Analysis name string>
 do_analysis_timeseries: <bool>
 jobs:
    <jobID1>:
@@ -151,10 +151,11 @@ jobs:
    <jobID2>:
       description: <descrption of the second job>      
 ```
-Where the `name` is the name of script and the ultimately the path of the
-comparison report.
+Where the `name` is a short unique string describing the analysis script
+and the ultimately the name given here will become part of the path
+of the final output comparison report.
 
-The `do_analysis_timeseries` bool lets analysis_compare send jobs to 
+The `do_analysis_timeseries` bool lets `analysis_compare` send jobs to 
 `analysis_timeseries`, allowing the user to run the entire suite in one 
 command, instead of individually running the `analysis_timeseries` then
 the `analysis_compare` part afterwards.
@@ -170,12 +171,6 @@ The optional arguments for each job are:
     
 A sample yaml exists in `input_yml/comparison_analysis_template.yml`,
 which can be adapted to additional analysis. 
-
-
-
-
-
-
 
 
 Documentation

--- a/bgcval2/Paths/paths.py
+++ b/bgcval2/Paths/paths.py
@@ -42,6 +42,8 @@ def paths_setter(paths_dict):
     paths.ModelFolder_pref = paths_dict["general"]["ModelFolder_pref"]
     paths.orcaGridfn = paths_dict["general"]["orcaGridfn"]
     paths.ObsFolder = paths_dict["general"]["ObsFolder"]
+    #paths.bgcval2data = paths_dict["general"]["bgcval2data"]
+
 
     # [data-files] paths; optional depending on site
     if "Dustdir" in paths_dict["data-files"]:

--- a/bgcval2/Paths/paths_local.py
+++ b/bgcval2/Paths/paths_local.py
@@ -53,7 +53,7 @@ root_dir = os.path.join("/home", os.environ.get("USER"))
 #####
 # Post processed Data location
 #shelvedir 	= folder("/group_workspaces/root_dir/ukesm/BGC_data/"+getuser()+"/shelves/")
-shelvedir = folder(root_dir + "/bgcval2_data/" + getuser() + "/shelves/")
+shelvedir = folder([root_dir, "bgcval2_data", getuser(), "shelves"])
 
 #####
 # Post processed p2p Data location

--- a/bgcval2/Paths/paths_local.py
+++ b/bgcval2/Paths/paths_local.py
@@ -53,21 +53,21 @@ root_dir = os.path.join("/home", os.environ.get("USER"))
 #####
 # Post processed Data location
 #shelvedir 	= folder("/group_workspaces/root_dir/ukesm/BGC_data/"+getuser()+"/shelves/")
-shelvedir = folder(root_dir + "/BGC_data/" + getuser() + "/shelves/")
+shelvedir = folder(root_dir + "/bgcval2_data/" + getuser() + "/shelves/")
 
 #####
 # Post processed p2p Data location
 #p2p_ppDir = folder("/group_workspaces/root_dir/ukesm/BGC_data/ukesm_postProcessed/")
-p2p_ppDir = folder(root_dir + "/BGC_data/ukesm_postProcessed/")
+p2p_ppDir = folder(root_dir + "/bgcval2_data/ukesm_postProcessed/")
 
 ######
 # Output location for plots.
-imagedir = folder(root_dir + '/BGC_data/' + getuser() + "/images/")
+imagedir = folder(root_dir + '/bgcval2_data/' + getuser() + "/images/")
 
 #####
 # Location of model files.
 #esmvalFolder 	= "/group_workspaces/root_dir/ukesm/BGC_data/"
-ModelFolder_pref = folder(root_dir + "/BGC_data/")
+ModelFolder_pref = folder(root_dir + "/bgcval2_data/")
 
 #####
 # eORCA1 grid

--- a/bgcval2/UKESMpython.py
+++ b/bgcval2/UKESMpython.py
@@ -77,7 +77,7 @@ def folder(name):
         name = name + '/'
     if exists(name) is False:
         makedirs(name)
-        print(('makedirs ', name))
+        print('makedirs ', name)
     return name
 
 

--- a/bgcval2/analysis_compare.py
+++ b/bgcval2/analysis_compare.py
@@ -131,7 +131,7 @@ def apply_shifttimes(mdata, jobID, shifttimes):
         
     for t in sorted(mdata.keys()):
         t1 = t + float(shifttimes[jobID])
-        times.append(float(t1))
+        times.append(t1)
         datas.append(mdata[t])        
     return times, datas       
    
@@ -177,7 +177,7 @@ def timeseries_compare(jobs,
 
     if analysisname == '':
         print('ERROR: please provide an name for this analsys')
-        exit(0)
+        sys.exit(0)
     else:
         imageFolder = paths.imagedir + '/TimeseriesCompare/' + analysisname
 
@@ -4253,7 +4253,7 @@ def main():
             )   
 
     # Master suite leys:
-    if not len(master_suites):
+    if not master_suites:
         master_suites=['physics', 'bio'] # Defaults
 
     # make sure its a list:
@@ -4261,7 +4261,7 @@ def main():
         master_suites = [m.lower() for m in master_suites]
     if isinstance(master_suites, str):
         master_suites = master_suites.lower()
-        for split_char in [' ', ',', ':', ';']:
+        for split_char in [' ', ',', ':']:
             master_suites = master_suites.replace(split_char, ';')
         master_suites = master_suites.split(';')
 

--- a/bgcval2/analysis_compare.py
+++ b/bgcval2/analysis_compare.py
@@ -4169,7 +4169,7 @@ def load_comparison_yml(fn):
 
     details['do_analysis_timeseries'] = dictionary.get('do_analysis_timeseries', False) 
     
-    details['master_suites'] = dictionary.get('master_suites', 'debug')
+    details['master_suites'] = dictionary.get('master_suites', [])
     
     thicknesses = defaultdict(lambda: 0.75)
     linestyles = defaultdict(lambda: '-')
@@ -4284,7 +4284,7 @@ def main():
         key_debug = True
     else:
         key_debug = False
- 
+
     timeseries_compare(
         jobs,
         colours = colours,

--- a/bgcval2/analysis_compare.py
+++ b/bgcval2/analysis_compare.py
@@ -4171,34 +4171,29 @@ def load_comparison_yml(fn):
     
     details['master_suites'] = dictionary.get('master_suites', [])
     
-    thicknesses = defaultdict(lambda: 0.75)
-    linestyles = defaultdict(lambda: '-')
+    default_thickness = 0.75
+    default_linestyle = '-'
+    default_suite = 'kmf'
+  
+    thicknesses = {}
+    linestyles = {}
     colours = {}
-    suites = defaultdict(lambda: 'kmf')
-    descriptions = defaultdict(lambda: '')
-    shifttimes = defaultdict(lambda: 0.) # number of years to shift time axis.
+    suites = {}
+    descriptions = {}
+    shifttimes = {} # number of years to shift time axis.
    
     for jobID, job_dict in details['jobs'].items():
         if job_dict.get('colour', False):
             colours[jobID] = job_dict['colour']
         else:
             colours[jobID] = ''.join(['#', "%06x" % random.randint(0, 0xFFFFFF)])        
-            print('WARNING: No colour provided, setting to random hex colour', colours[jobID])
+            print('WARNING: No colour provided, setting to random hex colour:', colours[jobID])
             
-        if job_dict.get('description', False):
-            descriptions[jobID] = job_dict['description']
-            
-        if job_dict.get('thickness', False):
-            thicknesses[jobID] = job_dict['thickness']
-
-        if job_dict.get('linestyle', False):
-            linestyles[jobID] = job_dict['linestyle'] 
-
-        if job_dict.get('shifttime', False):
-            shifttimes[jobID] = float(job_dict['shifttime'])
-            
-        if job_dict.get('suite', False):
-            suites[jobID] = job_dict['suite']            
+        descriptions[jobID] = job_dict.get('description', '')
+        thicknesses[jobID] = job_dict.get('thickness', default_thickness)
+        linestyles[jobID] = job_dict.get('linestyle', default_linestyle)
+        shifttimes[jobID] = float(job_dict.get('shifttime', 0.))
+        suites[jobID] = job_dict.get(suite, default_suite)
                  
     details['colours'] = colours
     details['descriptions'] = descriptions

--- a/bgcval2/analysis_compare.py
+++ b/bgcval2/analysis_compare.py
@@ -124,7 +124,7 @@ def apply_shifttimes(mdata, jobID, shifttimes):
     Outputs two lists: dates & data.
     """
     times, datas = [], []
-    if not len(mdata.keys():
+    if not len(mdata.keys()):
         return [], []
 
     t0 = float(sorted(mdata.keys())[0])
@@ -166,10 +166,10 @@ def timeseries_compare(jobs,
         jobs.remove(ensemble)
 
     # get runtime configuration
-    if config_user:
-        paths_dict, config_user = get_run_configuration(config_user)
-    else:
+    if not config_user:
         paths_dict, config_user = get_run_configuration("defaults")
+    else:
+        paths_dict, config_user = get_run_configuration(config_user)
 
     # filter paths dict into an object that's usable below
     paths = paths_setter(paths_dict)
@@ -3998,7 +3998,7 @@ def timeseries_compare(jobs,
     if method_images == 'glob':
         AllImages = glob(imageFolder, recursive=True)
         print('AllImages:','glob', AllImages)
-    if method_images == 'oswalk':
+    elif method_images == 'oswalk':
         for root, dirnames, filenames in os.walk(imageFolder):
             for filename in fnmatch.filter(filenames, '*.png'):
                 AllImages.append(os.path.join(root, filename))
@@ -4137,14 +4137,14 @@ def CompareTwoRuns(jobIDA,
                 scatter=False)
 
 
-def load_comparison_yml(fn):
+def load_comparison_yml(master_compare_yml_fn):
     """
     Load the config yaml.
     TAkes an file path string 
     Returns:
         Details dict.
     """
-    with open(fn, 'r') as openfile:
+    with open(master_compare_yml_fn, 'r') as openfile:
         dictionary = yaml.safe_load(openfile)
 
     details = {}    
@@ -4192,7 +4192,7 @@ def load_comparison_yml(fn):
         thicknesses[jobID] = job_dict.get('thickness', default_thickness)
         linestyles[jobID] = job_dict.get('linestyle', default_linestyle)
         shifttimes[jobID] = float(job_dict.get('shifttime', 0.))
-        suites[jobID] = job_dict.get(suite, default_suite)
+        suites[jobID] = job_dict.get('suite', default_suite)
                  
     details['colours'] = colours
     details['descriptions'] = descriptions
@@ -4210,18 +4210,17 @@ def main():
             print("Read the documentation.")
         exit(0)
 
-    details = load_comparison_yml(argv[1])
-
     config_user=None
     if "bgcval2-config-user.yml" in argv[1:]:
         config_user = "bgcval2-config-user.yml"
         print(f"analysis_timeseries: Using user config file {config_user}")
+
+    details = load_comparison_yml(argv[1])
   
     jobs = details['jobs']
     analysis_name = details['name']    
     do_analysis_timeseries = details['do_analysis_timeseries']
     master_suites = details['master_suites']  
-    # Working on this right now. 
  
     colours = details['colours']
     thicknesses = details['thicknesses']

--- a/bgcval2/analysis_compare.py
+++ b/bgcval2/analysis_compare.py
@@ -124,11 +124,10 @@ def apply_shifttimes(mdata, jobID, shifttimes):
     Outputs two lists: dates & data.
     """
     times, datas = [], []
-    try:
-        t0 = float(sorted(mdata.keys())[0])
-    except:
-        return times, datas
-        
+    if not len(mdata.keys():
+        return [], []
+
+    t0 = float(sorted(mdata.keys())[0])
     for t in sorted(mdata.keys()):
         t1 = t + float(shifttimes[jobID])
         times.append(t1)

--- a/bgcval2/analysis_compare.py
+++ b/bgcval2/analysis_compare.py
@@ -3993,13 +3993,18 @@ def timeseries_compare(jobs,
                             thicknesses=lineThicknesses,
                             linestyles=linestyles,
                         )
-    try:
+    #
+    method_images = 'oswalk'
+    AllImages = []
+    if method_images == 'glob':
         AllImages = glob(imageFolder, recursive=True)
-    except:
-        AllImages = []
+        print('AllImages:','glob', AllImages)
+    if method_images == 'oswalk':
         for root, dirnames, filenames in os.walk(imageFolder):
             for filename in fnmatch.filter(filenames, '*.png'):
                 AllImages.append(os.path.join(root, filename))
+                print('AllImages:','fors', root, dirnames, filenames, filename)
+ 
 
     if ensembles != {}:
         jobs = list(ensembles.keys())

--- a/bgcval2/analysis_timeseries.py
+++ b/bgcval2/analysis_timeseries.py
@@ -230,19 +230,18 @@ keymetricsfirstDict = {i: n for i, n in enumerate(keymetricsfirstKeys)}
 
 
 def listModelDataFiles(jobID, filekey, datafolder, annual):
-    print(
-        ("listing model data files:\njobID:\t", jobID, '\nfile key:\t',
-         filekey, '\ndata folder:\t', datafolder, '\nannual flag:\t', annual))
+    print("listing model data files:\njobID:\t", jobID, '\nfile key:\t',
+         filekey, '\ndata folder:\t', datafolder, '\nannual flag:\t', annual)
     if annual:
-        print(("listing model data files:",
-               datafolder + jobID + "/" + jobID + "o_1y_*_" + filekey + ".nc"))
+        print("listing model data files:",
+               datafolder + jobID + "/" + jobID + "o_1y_*_" + filekey + ".nc")
         datafolder = os.path.join(datafolder, jobID)
         model_files = sorted(
             glob(datafolder + "/" + jobID + "o_1y_*_" + filekey +
                  ".nc"))
     else:
-        print(("listing model data files:",
-               datafolder + jobID + "/" + jobID + "o_1m_*_" + filekey + ".nc"))
+        print("listing model data files:",
+               datafolder + jobID + "/" + jobID + "o_1m_*_" + filekey + ".nc")
         datafolder = os.path.join(datafolder, jobID)
         model_file = sorted(
             glob(datafolder + "/" + jobID + "o_1m_*_" + filekey +

--- a/bgcval2/analysis_timeseries.py
+++ b/bgcval2/analysis_timeseries.py
@@ -675,6 +675,17 @@ def analysis_timeseries(
             ukesmkeys['u3d'] = 'vozocrtx'
             ukesmkeys['e3u'] = 'e3u'
             ukesmkeys['w3d'] = 'vovecrtz'
+        elif 'thetao_con' in nctmpkeys: # Added keys for UKESM2.
+            ukesmkeys['time'] = 'time_counter'
+            ukesmkeys['temp3d']     = 'thetao_con'
+            ukesmkeys['sst']        = 'tos_con'
+            ukesmkeys['sal3d']     = 'so_abs'
+            ukesmkeys['sss']        = 'sos_abs'
+            ukesmkeys['v3d']     = 'vo'
+            ukesmkeys['u3d']     = 'uo'
+            ukesmkeys['e3u']    = 'thkcello'
+            ukesmkeys['w3d']     = 'wo'
+            ukesmkeys['MLD'] = 'somxzint1'
         else:
             ukesmkeys['time'] = 'time_centered'
             ukesmkeys['temp3d'] = 'thetao'

--- a/bgcval2/analysis_timeseries.py
+++ b/bgcval2/analysis_timeseries.py
@@ -137,7 +137,7 @@ if True:
     #	physKeys.append('MeridionalCurrent')        	# Meridional Veloctity
     #	physKeys.append('VerticalCurrent')          	# Vertical Veloctity
 
-    physKeys.append('FreshwaterFlux')  # Freshwater flux
+    #physKeys.append('FreshwaterFlux')  # Freshwater flux
     physKeys.append('sowaflup')  # Net Upward Water Flux
     #	physKeys.append('soicecov')			# Ice fraction
 
@@ -252,11 +252,11 @@ def listModelDataFiles(jobID, filekey, datafolder, annual):
 
 def analysis_timeseries(
     jobID="u-ab671",
+    analysisSuite='all',
+    regions='all',
     clean=0,
     annual=True,
     strictFileCheck=True,
-    analysisSuite='all',
-    regions='all',
     config_user=None
 ):
     """
@@ -282,6 +282,15 @@ def analysis_timeseries(
 	:param regions:
 
 	"""
+
+    print('-----------------------')
+    print('Starting analysis_timeseries')
+    print('jobID:', jobID)
+    print('analysisSuite:',analysisSuite)
+    print('regions:', regions)
+    print('clean:',  clean, 'annual:',annual, 'strictFileCheck:', strictFileCheck)
+    print('config_user:', config_user)   
+
     # get runtime configuration
     if config_user:
         paths_dict, config_user = get_run_configuration(config_user)
@@ -356,6 +365,8 @@ def analysis_timeseries(
         if analysisSuite.lower() in [
                 'debug',
         ]:
+            analysisKeys.append('AMOC_26N')                # AMOC 26N
+
             #analysisKeys.append('AirSeaFlux')		# work in progress
             #analysisKeys.append('TotalAirSeaFluxCO2')	# work in progress
             #analysisKeys.append('NoCaspianAirSeaFluxCO2')	# work in progress
@@ -364,20 +375,20 @@ def analysis_timeseries(
             #analysisKeys.append('OMZMeanDepth')		# work in progress
             #analysisKeys.append('OMZThickness')            # Oxygen Minimum Zone Thickness
             #analysisKeys.append('TotalOMZVolume')		# work in progress
-            analysisKeys.append('O2')  # WOA Oxygen
+            #analysisKeys.append('O2')  # WOA Oxygen
             #analysisKeys.append('AOU')                      # Apparent Oxygen Usage
             #analysisKeys.append('WindStress')               # Wind Stress
             #analysisKeys.append('Dust')                    # Dust
             #analysisKeys.append('TotalDust')               # Total Dust
             #analysisKeys.append('TotalDust_nomask')
-            analysisKeys.append('DIC')  # work in progress
+            #analysisKeys.append('DIC')  # work in progress
             #analysisKeys.append('DrakePassageTransport')	# DrakePassageTransport
             #analysisKeys.append('TotalIceArea')		# work in progress
             #analysisKeys.append('CHN')
             #analysisKeys.append('CHD')
             #analysisKeys.append('CHL')
             #analysisKeys.append('pH')
-            analysisKeys.append('Alk')  # Glodap Alkalinity
+            #analysisKeys.append('Alk')  # Glodap Alkalinity
 
             #if jobID in ['u-am004','u-am005']:
             #        analysisKeys.append('DMS_ANDR')                 # DMS Anderson
@@ -387,9 +398,9 @@ def analysis_timeseries(
             #analysisKeys.append('Iron')			# work in progress
             #analysisKeys.append('DTC')                 # work in progress
 
-            analysisKeys.append('Iron')  # work in progress
-            analysisKeys.append('N')  # WOA Nitrate
-            analysisKeys.append('Si')  # WOA Nitrate
+            #analysisKeys.append('Iron')  # work in progress
+            #analysisKeys.append('N')  # WOA Nitrate
+            #analysisKeys.append('Si')  # WOA Nitrate
             #analysisKeys.append('IntPP_OSU')               # OSU Integrated primpary production
             #analysisKeys.append('Chl_CCI')
         #analysisKeys.append('CHL_MAM')
@@ -462,17 +473,17 @@ def analysis_timeseries(
 
 #####
 # Physics switches:
-    if jobID in [
-            'u-aj588',
-            'u-ak900',
-            'u-ar538',
-            'u-an869',
-            'u-ar977',
-    ]:
-        try:
-            analysisKeys.remove('FreshwaterFlux')
-        except:
-            pass
+#    if jobID in [
+#            'u-aj588',
+#            'u-ak900',
+#            'u-ar538',
+#            'u-an869',
+#            'u-ar977',
+#    ]:
+#        try:
+#            analysisKeys.remove('FreshwaterFlux')
+#        except:
+#            pass
 
     #####
     # Some lists of region.
@@ -568,9 +579,14 @@ def analysis_timeseries(
     # Feel free to add other macihines onto this list, if need be.
     machinelocation = ''
 
+
+    shelvedir = ukp.folder(paths.shelvedir + "/timeseries/" + jobID)
+
     #####
     # PML
-    if gethostname().find('pmpc') > -1:
+    hostname = gethostname()
+
+    if hostname.find('pmpc') > -1:
         print(("analysis-timeseries.py:\tBeing run at PML on ", gethostname()))
 
         imagedir = ukp.folder(paths.imagedir + '/' + jobID + '/timeseries')
@@ -579,10 +595,9 @@ def analysis_timeseries(
         else: WOAFolder = paths.WOAFolder
 
         #shelvedir 	= ukp.folder(paths.shelvedir+'/'+jobID+'/timeseries/'+jobID)
-        shelvedir = ukp.folder(paths.shelvedir + "/timeseries/" + jobID)
+        #shelvedir = ukp.folder(paths.shelvedir + "/timeseries/" + jobID)
     #####
     # JASMIN
-    hostname = gethostname()
     if hostname.find('ceda.ac.uk') > -1 or hostname.find(
             'jasmin') > -1 or hostname.find('jc.rl.ac.uk') > -1:
         print(("analysis-timeseries.py:\tBeing run at CEDA on ", hostname))
@@ -590,12 +605,12 @@ def analysis_timeseries(
 
         #try:	shelvedir 	= ukp.folder("/group_workspaces/jasmin2/ukesm/BGC_data/"+getuser()+"/shelves/timeseries/"+jobID)
         #except: shelvedir       =            "/group_workspaces/jasmin2/ukesm/BGC_data/"+getuser()+"/shelves/timeseries/"+jobID
-        try:
-            shelvedir = ukp.folder("/gws/nopw/j04/ukesm/BGC_data/" +
-                                   getuser() + "/shelves/timeseries/" + jobID)
-        except:
-            shelvedir = "/gws/nopw/j04/ukesm/BGC_data/" + getuser(
-            ) + "/shelves/timeseries/" + jobID
+        #try:
+        #    shelvedir = ukp.folder("/gws/nopw/j04/ukesm/BGC_data/" +
+        #                           getuser() + "/shelves/timeseries/" + jobID)
+        #except:
+        #    shelvedir = "/gws/nopw/j04/ukesm/BGC_data/" + getuser(
+        #    ) + "/shelves/timeseries/" + jobID
 
         if annual: WOAFolder = paths.WOAFolder_annual
         else: WOAFolder = paths.WOAFolder
@@ -605,7 +620,7 @@ def analysis_timeseries(
         except:
             imagedir = paths.imagedir + '/' + jobID + '/timeseries'
 
-    if gethostname().find('monsoon') > -1:
+    if hostname.find('monsoon') > -1:
         print("Please set up paths.py")
         assert 0
 
@@ -674,16 +689,17 @@ def analysis_timeseries(
             ukesmkeys['u3d'] = 'vozocrtx'
             ukesmkeys['e3u'] = 'e3u'
             ukesmkeys['w3d'] = 'vovecrtz'
+            ukesmkeys['MLD'] = 'ssomxl010'
         elif 'thetao_con' in nctmpkeys: # Added keys for UKESM2.
             ukesmkeys['time'] = 'time_counter'
-            ukesmkeys['temp3d']     = 'thetao_con'
-            ukesmkeys['sst']        = 'tos_con'
-            ukesmkeys['sal3d']     = 'so_abs'
-            ukesmkeys['sss']        = 'sos_abs'
-            ukesmkeys['v3d']     = 'vo'
-            ukesmkeys['u3d']     = 'uo'
-            ukesmkeys['e3u']    = 'thkcello'
-            ukesmkeys['w3d']     = 'wo'
+            ukesmkeys['temp3d'] = 'thetao_con'
+            ukesmkeys['sst'] = 'tos_con'
+            ukesmkeys['sal3d'] = 'so_abs'
+            ukesmkeys['sss'] = 'sos_abs'
+            ukesmkeys['v3d'] = 'vo'
+            ukesmkeys['u3d'] = 'uo'
+            ukesmkeys['e3u'] = 'thkcello'
+            ukesmkeys['w3d'] = 'wo'
             ukesmkeys['MLD'] = 'somxzint1'
         else:
             ukesmkeys['time'] = 'time_centered'
@@ -695,6 +711,8 @@ def analysis_timeseries(
             ukesmkeys['u3d'] = 'uo'
             ukesmkeys['e3u'] = 'thkcello'
             ukesmkeys['w3d'] = 'wo'
+            ukesmkeys['MLD'] = 'ssomxl010'
+
 #	else:
 #                        ukesmkeys['time']       = 'time_centered'
 #                        ukesmkeys['temp3d']     = 'thetao'
@@ -3813,9 +3831,7 @@ def analysis_timeseries(
 
         av[name]['modeldetails'] = {
             'name': 'mld',
-            'vars': [
-                'somxl010',
-            ],
+            'vars': [ ukesmkeys['MLD'],],
             'convert': applySurfaceMask,
             'units': 'm'
         }

--- a/bgcval2/default-bgcval2-config.yml
+++ b/bgcval2/default-bgcval2-config.yml
@@ -8,9 +8,9 @@ standard-paths:
     general:
       machinelocation: "JASMIN"
       root_dir: "/gws/nopw/j04/ukesm"
-      shelvedir: "shelves"
-      p2p_ppDir: "ukesm_postProcessed"
-      imagedir: "images"
+      shelvedir: "bgcval2/shelves"
+      p2p_ppDir: "bgcval2/ukesm_postProcessed"
+      imagedir: "bgcval2/images"
       ModelFolder_pref: "BGC_data"
       orcaGridfn: "/gws/nopw/j04/esmeval/bgc-val/mesh_mask_eORCA1_wrk.nc"
       ObsFolder: "/gws/nopw/j04/esmeval/example_data/bgc"

--- a/bgcval2/html5/html5Tools.py
+++ b/bgcval2/html5/html5Tools.py
@@ -163,7 +163,7 @@ def AddSection(filepath, href, Title, Description='', Files=[]):
 
     #####
     # Copy the template and add the images.
-    f = open("html5/section-template.html", "r")
+    f = open("bgcval2/html5/section-template.html", "r")
     contents = f.readlines()
     f.close()
     if type(Files) == type([

--- a/bgcval2/makeReport.py
+++ b/bgcval2/makeReport.py
@@ -71,9 +71,21 @@ def addImageToHtml(fn, imagesfold, reportdir, debug=True):
     newfn = imagesfold + os.path.basename(fn)
     relfn = newfn.replace(reportdir, './')
 
+    if debug:
+        print("addImageToHtml:\tfn:", fn, 
+            "imagesfold:", imagesfold, 
+            "reportdir:", reportdir,
+            "newfn:", newfn,
+            "relfn:", relfn)
+
+    
     if not os.path.exists(newfn):
-        if debug: print("cp", fn, newfn)
-        shutil.copy2(fn, newfn)
+        if debug: print("addImageToHtml:\tcopytree", fn, newfn)
+        copytree(fn, newfn)
+#       if os.path.isdir(fn):
+#               shutil.copytree(fn, newfn, symlinks, ignore)
+#       else:
+#           shutil.copy2(fn, newfn)
     else:
         ####
         # Check if the newer file is the same one from images.
@@ -84,10 +96,10 @@ def addImageToHtml(fn, imagesfold, reportdir, debug=True):
                 fn,
                 newfn,
         ):
-            if debug: print("removing old file", fn)
+            if debug: print("addImageToHtml:\tremoving old file", fn)
             os.remove(newfn)
             shutil.copy2(fn, newfn)
-            if debug: print("cp", fn, newfn)
+            if debug: print("addImageToHtml:\t copy2", fn, newfn)
     return relfn
 
 
@@ -118,7 +130,7 @@ def html5Maker(
     # Copy all necceasiry objects and templates to the report location:
     print("Copying html and js assets to", reportdir)
     basedir = os.path.dirname(__file__)
-    copytree(os.path.join(basedir, 'html5/html5Assets'), reportdir)
+    copytree(os.path.join(basedir, 'bgcval2/html5/html5Assets'), reportdir)
     indexhtmlfn = reportdir + "index.html"
     try:
         os.rename(reportdir + 'index-template.html', indexhtmlfn)
@@ -1289,7 +1301,7 @@ def html5Maker(
 
     if regionMap:
         vfiles = []
-        vfiles.extend(glob('html5/html5Assets/images/*Legend*.png'))
+        vfiles.extend(glob('bgcval2/html5/html5Assets/images/*Legend*.png'))
         relfns = [addImageToHtml(fn, imagesfold, reportdir) for fn in vfiles]
         print(relfns)
         href = 'regionMap_default'
@@ -1347,7 +1359,7 @@ def comparehtml5Maker(
     ####
     # Copy all necceasiry objects and templates to the report location:
     print("Copying html and js assets to", reportdir)
-    copytree('html5/html5Assets', reportdir)
+    copytree('bgcval2/html5/html5Assets', reportdir)
     indexhtmlfn = reportdir + "index.html"
     try:
         os.rename(reportdir + 'index-compare-template.html', indexhtmlfn)
@@ -1663,7 +1675,7 @@ def comparehtml5Maker(
     legend = True
     if legend:
         vfiles = []
-        vfiles.extend(glob('html5/html5Assets/images/*Legend*.png'))
+        vfiles.extend(glob('bgcval2/html5/html5Assets/images/*Legend*.png'))
         relfns = [addImageToHtml(fn, imagesfold, reportdir) for fn in vfiles]
         print(relfns)
         href = 'regionMap_default'

--- a/bgcval2/makeReport.py
+++ b/bgcval2/makeReport.py
@@ -100,7 +100,8 @@ def addImageToHtml(fn, imagesfold, reportdir, debug=True):
             if debug: print("addImageToHtml:\tremoving old file", fn)
             os.remove(newfn)
             shutil.copy2(fn, newfn)
-            if debug: print("addImageToHtml:\t copy2", fn, newfn)
+            if debug: 
+                print("addImageToHtml:\t copy2", fn, newfn)
     return relfn
 
 

--- a/bgcval2/makeReport.py
+++ b/bgcval2/makeReport.py
@@ -73,19 +73,20 @@ def addImageToHtml(fn, imagesfold, reportdir, debug=True):
 
     if debug:
         print("addImageToHtml:\tfn:", fn, 
-            "imagesfold:", imagesfold, 
-            "reportdir:", reportdir,
-            "newfn:", newfn,
-            "relfn:", relfn)
+            "\n\timagesfold:", imagesfold, 
+            "\n\treportdir:", reportdir,
+            "\n\tnewfn:", newfn,
+            "\n\trelfn:", relfn)
 
     
     if not os.path.exists(newfn):
         if debug: print("addImageToHtml:\tcopytree", fn, newfn)
-        copytree(fn, newfn)
-#       if os.path.isdir(fn):
-#               shutil.copytree(fn, newfn, symlinks, ignore)
-#       else:
-#           shutil.copy2(fn, newfn)
+        basedir = folder(os.path.dirname(newfn))
+        #copytree(fn, newfn)
+        if os.path.isdir(fn):
+            shutil.copytree(fn, newfn, symlinks, ignore)
+        else:
+            shutil.copy2(fn, newfn)
     else:
         ####
         # Check if the newer file is the same one from images.
@@ -525,6 +526,7 @@ def html5Maker(
             for fn in vfiles:
                 #####
                 # Copy image to image folder and return relative path.
+                print('create plot headers:', fn)
                 relfn = addImageToHtml(fn, imagesfold, reportdir)
 
                 ####
@@ -659,6 +661,7 @@ def html5Maker(
                 #if fn.lower().find('surface')<0 or fn.lower().find('layerless')<0:continue
                 #####
                 # Copy image to image folder and return relative path.
+                print('adding Level1 regional plot:', jobID, fn)
                 relfn = addImageToHtml(fn, imagesfold, reportdir)
 
                 #####
@@ -772,6 +775,8 @@ def html5Maker(
 
                     #####
                     # Copy image to image folder and return relative path.
+                    print('adding Level1 Profile plot:', jobID, fn)
+
                     relfn = addImageToHtml(fn, imagesfold, reportdir)
 
                     #####
@@ -911,6 +916,7 @@ def html5Maker(
 
                 #####
                 # Copy image to image folder and return relative path.
+                print('adding Level2  plot:', jobID, fn)
                 relfn = addImageToHtml(fn, imagesfold, reportdir)
 
                 #####
@@ -1024,6 +1030,7 @@ def html5Maker(
 
                 #####
                 # Copy image to image folder and return relative path.
+                print('adding Level2 Feilds plot:', jobID, fn)
                 relfn = addImageToHtml(fn, imagesfold, reportdir)
 
                 #####
@@ -1111,6 +1118,7 @@ def html5Maker(
             for fn in vfiles:
                 #####
                 # Copy image to image folder and return relative path.
+                print('adding Level3 plot:', jobID, fn)
                 relfn = addImageToHtml(fn, imagesfold, reportdir)
 
                 #####
@@ -1203,6 +1211,7 @@ def html5Maker(
                 #if fn.lower().find('surface')<0 or fn.lower().find('layerless')<0:continue
                 #####
                 # Copy image to image folder and return relative path.
+                print('adding Level3 regional plot:', fn)
                 relfn = addImageToHtml(fn, imagesfold, reportdir)
 
                 #####
@@ -1278,6 +1287,7 @@ def html5Maker(
 
                     #####
                     # Copy image to image folder and return relative path.
+                    print('adding Level3 Hovmoeller:',  fn)
                     relfn = addImageToHtml(fn, imagesfold, reportdir)
 
                     #####
@@ -1302,6 +1312,8 @@ def html5Maker(
     if regionMap:
         vfiles = []
         vfiles.extend(glob('bgcval2/html5/html5Assets/images/*Legend*.png'))
+        print('adding Legend')
+
         relfns = [addImageToHtml(fn, imagesfold, reportdir) for fn in vfiles]
         print(relfns)
         href = 'regionMap_default'
@@ -1529,6 +1541,7 @@ def comparehtml5Maker(
 
         #####
         # Copy image to image folder and return relative path.
+        print('adding compare plots')
         relativeFiles = [
             addImageToHtml(catfn, imagesfold, reportdir) for catfn in catfiles
         ]
@@ -1616,6 +1629,7 @@ def comparehtml5Maker(
             for fn in sorted(vfiles):
                 #####
                 # Copy image to image folder and return relative path.
+                print('Adding ', key, 'compare plots:', fn)
                 relfn = addImageToHtml(fn, imagesfold, reportdir)
 
                 #####
@@ -1643,6 +1657,7 @@ def comparehtml5Maker(
             for fn in sorted(otherFilenames):
                 #####
                 # Copy image to image folder and return relative path.
+                print('Adding ', key, 'compare plots:', fn)
                 relfn = addImageToHtml(fn, imagesfold, reportdir)
 
                 #####
@@ -1676,6 +1691,7 @@ def comparehtml5Maker(
     if legend:
         vfiles = []
         vfiles.extend(glob('bgcval2/html5/html5Assets/images/*Legend*.png'))
+        print('Adding compare plots legend')
         relfns = [addImageToHtml(fn, imagesfold, reportdir) for fn in vfiles]
         print(relfns)
         href = 'regionMap_default'

--- a/bgcval2/timeseries/timeseriesAnalysis.py
+++ b/bgcval2/timeseries/timeseriesAnalysis.py
@@ -158,7 +158,7 @@ class timeseriesAnalysis:
             print(
                 "timeseriesAnalysis:\tloadModel\tUser requested clean run. Wiping old data."
             )
-        elif len(glob.glob(''.join([self.shelvefn, '*']))):
+        elif glob.glob(''.join([self.shelvefn, '*'])):
             print("timeseriesAnalysis:\tloadModel\tOpening shelve:",
                    self.shelvefn)
 

--- a/bgcval2/timeseries/timeseriesPlots.py
+++ b/bgcval2/timeseries/timeseriesPlots.py
@@ -116,8 +116,8 @@ def percentilesPlot(
         maxy = np.ma.max(modeldataDict['80pc'])
 
     if miny in [np.ma.masked, np.nan, np.inf]:
-        print(("percentilesPlot:\tIt is not possible to make this plot,(",
-              title, "), as the min values are no plottable:", miny))
+        print("percentilesPlot:\tIt is not possible to make this plot,(",
+              title, "), as the min values are no plottable:", miny)
         return
 
     #####
@@ -389,12 +389,12 @@ def percentilesPlot(
     #axm.set_yticklabels(ytickLabels,fontsize=10)
     #axm.yaxis.tick_right()
 
-    print(("timeseriesPlots:\tpercentilesPlot:\tSaving:", filename))
+    print("timeseriesPlots:\tpercentilesPlot:\tSaving:", filename)
     try:
         pyplot.savefig(filename)
     except:
-        print(("WARNING: THIS PLOT FAILED:", filename,
-              '(probably beaucse of all masks/ infs./nans)'))
+        print("WARNING: THIS PLOT FAILED:", filename,
+              '(probably beaucse of all masks/ infs./nans)')
     pyplot.close()
 
 
@@ -415,12 +415,12 @@ def trafficlightsPlot(
     #####
     # This is exclusively used for sums now.
     if len(times) == 0 or len(arr) == 0:
-        print(("trafficlightsPlot:\tWARNING:\tdata or time arrays are empty.",
-              len(times), len(arr), title))
+        print("trafficlightsPlot:\tWARNING:\tdata or time arrays are empty.",
+              len(times), len(arr), title)
         return
     if np.ma.is_masked(arr):
-        print(("trafficlightsPlot:\tWARNING:\tdata arrays is masked",
-              len(times), len(arr), title))
+        print("trafficlightsPlot:\tWARNING:\tdata arrays is masked",
+              len(times), len(arr), title)
         return
 
     xlims = [times[0], times[-1]]
@@ -516,7 +516,7 @@ def trafficlightsPlot(
     legend.draw_frame(False)
     legend.get_frame().set_alpha(0.)
 
-    print(("timeseriesPlots:\ttrafficlightsPlot:\tSaving:", filename))
+    print("timeseriesPlots:\ttrafficlightsPlot:\tSaving:", filename)
     pyplot.savefig(filename)
     pyplot.close()
 
@@ -533,12 +533,12 @@ def simpletimeseries(
     # This is exclusively used for sums now.
     #title = ' '.join([getLongName(t) for t in title])
     if len(times) == 0 or len(arr) == 0:
-        print(("simpletimeseries:\tWARNING:\tdata or time arrays are empty.",
-              len(times), len(arr), title))
+        print("simpletimeseries:\tWARNING:\tdata or time arrays are empty.",
+              len(times), len(arr), title)
         return
     if np.ma.is_masked(arr):
-        print(("simpletimeseries:\tWARNING:\tdata arrays is masked", len(times),
-              len(arr), title))
+        print("simpletimeseries:\tWARNING:\tdata arrays is masked", len(times),
+              len(arr), title)
         return
 
     xlims = [times[0], times[-1]]
@@ -576,7 +576,7 @@ def simpletimeseries(
     legend.draw_frame(False)
     legend.get_frame().set_alpha(0.)
 
-    print(("timeseriesPlots:\tsimpletimeseries:\tSaving:", filename))
+    print("timeseriesPlots:\tsimpletimeseries:\tSaving:", filename)
     pyplot.savefig(filename)
     pyplot.close()
 
@@ -672,8 +672,8 @@ def movingaverage2(x, window_len=11, window='flat', extrapolate='axially'):
         y = np.convolve(w / w.sum(), s, mode='same')
     returning = y[window_len - 1:-window_len + 1]
     if len(x) != len(returning):
-        print(("output array is not the same size as input:\tin:", len(x),
-              '\tout:', len(returning)))
+        print("output array is not the same size as input:\tin:", len(x),
+              '\tout:', len(returning))
         assert 0
     counts = np.arange(len(x))
     return np.ma.masked_where(
@@ -756,8 +756,8 @@ def multitimeseries(
     for i, jobID in enumerate(sorted(timesD.keys())):
         if len(arrD[jobID]): emptydat = False
     if emptydat:
-        print(("No data for this figure:", plotStyle, list(timesD.keys()),
-              title, filename))
+        print("No data for this figure:", plotStyle, list(timesD.keys()),
+              title, filename)
         return
 
     fig = pyplot.figure()
@@ -790,9 +790,9 @@ def multitimeseries(
         arr = arrD[jobID]
         #print 'multitimeseries: ', len(times), len(arr)
         try:
-            print(("multitimeseries:", jobID, dataname, min(times), max(times)))
+            print("multitimeseries:", jobID, dataname, min(times), max(times))
         except:
-            print(("multitimeseries:", jobID, dataname, 'no data'))
+            print("multitimeseries:", jobID, dataname, 'no data')
 
         if plotStyle == 'Separate':
             if len(list(timesD.keys())) <= 4:
@@ -804,19 +804,19 @@ def multitimeseries(
             elif len(list(timesD.keys())) <= 12:
                 axs.append(fig.add_subplot(3, 4, i + 1))
             else:
-                print(("Something is wrong here", i, plotStyle,
-                      len(list(timesD.keys())), jobID))
-            print(("Separate plots", i, jobID, len(list(timesD.keys())),
-                  len(axs)))
+                print("Something is wrong here", i, plotStyle,
+                      len(list(timesD.keys())), jobID)
+            print("Separate plots", i, jobID, len(list(timesD.keys())),
+                  len(axs))
             axs[i].set_title(jobID)
 
         if len(times) == 0 or len(arr) == 0:
-            print(("multitimeseries:\tWARNING:\tdata or time arrays are empty.",
-                  len(times), len(arr), title, (i, jobID)))
+            print("multitimeseries:\tWARNING:\tdata or time arrays are empty.",
+                  len(times), len(arr), title, (i, jobID))
             continue
         if np.ma.is_masked(arr):
-            print(("multitimeseries:\tWARNING:\tdata arrays is masked",
-                  len(times), len(arr), title, (i, jobID)))
+            print("multitimeseries:\tWARNING:\tdata arrays is masked",
+                  len(times), len(arr), title, (i, jobID))
             continue
 
         if times[0] < xlims[0]: xlims[0] = times[0]
@@ -1055,7 +1055,7 @@ def multitimeseries(
             ax.set_ylim(ylims)
         pyplot.suptitle(title)
 
-    print(("multitimeseries:\tsimpletimeseries:\tSaving:", filename))
+    print("multitimeseries:\tsimpletimeseries:\tSaving:", filename)
     pyplot.savefig(filename)
     pyplot.close()
 
@@ -1113,8 +1113,8 @@ def makemapplot(
         print("makemapplot: \tMasking")
         data = np.ma.masked_less_equal(ma.array(data), 0.)
 
-    print((data.min(), lats.min(), lons.min(), data.shape, lats.shape,
-          lons.shape))
+    print('makemapplot', data.min(), lats.min(), lons.min(), data.shape, lats.shape,
+          lons.shape)
 
     if data.ndim == 1:
         if doLog:
@@ -1212,7 +1212,7 @@ def mapPlotSingle(
         doLog=doLog,
     )
     ax1.set_extent([-180., 180., -90., 90.])
-    print(("mapPlotSingle.py:\tSaving:", filename))
+    print("mapPlotSingle.py:\tSaving:", filename)
     pyplot.savefig(filename, dpi=dpi)
     pyplot.close()
 
@@ -1314,7 +1314,7 @@ def mapPlotPair(
         if False in [fig, ax2]: assert False
         ax2.set_extent([-180., 180., -90., 90.])
 
-        print(("mapPlotPair: \tSaving:", filename))
+        print("mapPlotPair: \tSaving:", filename)
         pyplot.savefig(filename, dpi=dpi)
         pyplot.close()
     except:
@@ -1349,11 +1349,11 @@ def hovmoellerAxis(fig,
         if yaxis.mean() < 0: yaxis = np.clip(yaxis, -10000., -0.1)
 
     if debug:
-        print(("hovmoellerAxis:\txaxis:", title, xaxis, "\tyaxis:", yaxis,
-              "\tdata:", data))
+        print("hovmoellerAxis:\txaxis:", title, xaxis, "\tyaxis:", yaxis,
+              "\tdata:", data)
     if debug:
-        print(("hovmoellerAxis:\txaxis:", title, xaxis.shape, "\tyaxis:",
-              yaxis.shape, "\tdata:", data.shape))
+        print("hovmoellerAxis:\txaxis:", title, xaxis.shape, "\tyaxis:",
+              yaxis.shape, "\tdata:", data.shape)
 
     if vmin == vmax == '': p = pyplot.pcolormesh(xaxis, yaxis, data, cmap=cmap)
     else:
@@ -1429,10 +1429,10 @@ def hovmoellerPlot(modeldata,
     md = np.ma.masked_where(np.ma.masked_invalid(md).mask + md.mask, md)
     times = taxisfromCC(np.array(times_cc))
     yaxis = zaxisfromCC(yaxis_cc)
-    print(("hovmoellerPlot model:", title, md.shape, md.mean(), times.shape,
-          yaxis.shape))  #, times, yaxis
+    print("hovmoellerPlot model:", title, md.shape, md.mean(), times.shape,
+          yaxis.shape)  #, times, yaxis
     if len(md.shape) == 1 or 1 in md.shape:
-        print(("Not enough model data dimensions:", md.shape))
+        print("Not enough model data dimensions:", md.shape)
         return
 
     #####
@@ -1448,11 +1448,11 @@ def hovmoellerPlot(modeldata,
         dd.append(dataslice[l])
     if len(dd):
         dd = np.ma.array(dd)  #.squeeze()
-        print(("hovmoellerPlot data: (pre-mask)", title, '\t', dd.shape,
-              dd.min(), dd.mean(), dd.max()))
+        print("hovmoellerPlot data: (pre-mask)", title, '\t', dd.shape,
+              dd.min(), dd.mean(), dd.max())
         dd = np.ma.masked_where(np.ma.masked_invalid(dd).mask + dd.mask, dd)
-        print(("hovmoellerPlot data: (post-mask)", title, '\t', dd.shape,
-              dd.min(), dd.mean(), dd.max()))
+        print("hovmoellerPlot data: (post-mask)", title, '\t', dd.shape,
+              dd.min(), dd.mean(), dd.max())
         dyaxis_cc = np.array(dyaxis_cc)
     else:
         dd = np.ma.array([
@@ -1468,7 +1468,7 @@ def hovmoellerPlot(modeldata,
         if dd.shape[-1] == 1:
             dd = dd[:, :, 0]
         if len(dd.shape) > 2 and dd.shape[-1] != 1:
-            print(("Something very strange is happenning with this array:", dd))
+            print("Something very strange is happenning with this array:", dd)
             assert False
 
     dxaxis = np.array([
@@ -1476,8 +1476,8 @@ def hovmoellerPlot(modeldata,
         1,
     ])
     dyaxis = zaxisfromCC(dyaxis_cc)
-    print(("hovmoellerPlot: - data:", title, dd.shape, dd.mean(), dxaxis.shape,
-          dyaxis.shape))
+    print("hovmoellerPlot: - data:", title, dd.shape, dd.mean(), dxaxis.shape,
+          dyaxis.shape)
 
     if len(dd.squeeze().compressed()) == 0 and diff:
         print(
@@ -1617,7 +1617,7 @@ def hovmoellerPlot(modeldata,
     pyplot.xlabel('Year')
 
     pyplot.tight_layout()
-    print(("hovmoellerPlot.py: \tSaving:", filename))
+    print("hovmoellerPlot.py: \tSaving:", filename)
     pyplot.savefig(filename, dpi=dpi)
     pyplot.close()
 
@@ -1656,7 +1656,7 @@ def profilePlot(
     #yaxis = zaxisfromCC(yaxis_cc)
     #print "profilePlot model:", title, md.shape,md.mean(),times.shape,yaxis.shape #, times, yaxis
     if len(md.shape) == 1 or 1 in md.shape:
-        print(("Not enough model data dimensions:", md.shape))
+        print("Not enough model data dimensions:", md.shape)
         return
 
     #####
@@ -1673,11 +1673,11 @@ def profilePlot(
 
     if len(dd):
         dd = np.ma.array(dd)  #.squeeze()
-        print(("profilePlot data: (pre-mask)", title, '\t', dd.shape, dd.min(),
-              dd.mean(), dd.max()))
+        print("profilePlot data: (pre-mask)", title, '\t', dd.shape, dd.min(),
+              dd.mean(), dd.max())
         dd = np.ma.masked_where(np.ma.masked_invalid(dd).mask + dd.mask, dd)
-        print(("profilePlot data: (post-mask)", title, '\t', dd.shape, dd.min(),
-              dd.mean(), dd.max()))
+        print("profilePlot data: (post-mask)", title, '\t', dd.shape, dd.min(),
+              dd.mean(), dd.max())
         dyaxis_cc = np.abs(np.array(dyaxis_cc)) * -1.
     else:
         dd = np.ma.array([
@@ -1747,8 +1747,8 @@ def profilePlot(
     # Add model data
     plotDetails = {}
     for i in sorted(profileTimes.keys()):
-        print(('profilePlot', i, profileTimes[i], md[:, i].shape,
-              yaxis_cc.shape))
+        print('profilePlot', i, profileTimes[i], md[:, i].shape,
+              yaxis_cc.shape)
         lw = 1
         if i == lastyr: lw = 2
         color = defcmap((float(profileTimes[i]) - times_cc[0]) /
@@ -1769,7 +1769,7 @@ def profilePlot(
     pyplot.xlabel(xaxislabel)
     pyplot.ylabel('Depth')
     pyplot.title(title)
-    print(('x', rbmi, '->', rbma, 'z:', zmi, '->', zma))
+    print('x', rbmi, '->', rbma, 'z:', zmi, '->', zma)
 
     #ax1.set_yscale('log')	# Doesn't like negative values
 
@@ -1829,6 +1829,6 @@ def profilePlot(
     #legend.get_frame().set_alpha(0.)
 
     #pyplot.tight_layout()
-    print(("profilePlot.py: \tSaving:", filename))
+    print("profilePlot.py: \tSaving:", filename)
     pyplot.savefig(filename, dpi=dpi)
     pyplot.close()

--- a/input_yml/GC5N96ORCA1spinup.yml
+++ b/input_yml/GC5N96ORCA1spinup.yml
@@ -3,7 +3,7 @@
 name: GC5N96ORCA1spinup
 
 # Run the single job Analysis
-do_analysis_timeseries: False
+do_analysis_timeseries: True 
 
 # Job ID's suites as named by Rose/Cylc
 jobs:

--- a/input_yml/GC5N96ORCA1spinup.yml
+++ b/input_yml/GC5N96ORCA1spinup.yml
@@ -2,7 +2,7 @@
 # GC5 N96 ORCA1 spinup analysis
 name: GC5N96ORCA1spinup
 
-# Run the single job Analysis
+# Run the single job analysis
 do_analysis_timeseries: True 
 
 # Job ID's suites as named by Rose/Cylc

--- a/input_yml/GC5N96ORCA1spinup.yml
+++ b/input_yml/GC5N96ORCA1spinup.yml
@@ -1,0 +1,29 @@
+---
+# GC5 N96 ORCA1 spinup analysis
+name: GC5N96ORCA1spinup
+
+# Run the single job Analysis
+do_analysis_timeseries: False
+
+# Job ID's suites as named by Rose/Cylc
+jobs:
+    u-cm977: 
+        description: 'GC5 N96 ORCA1 spin-up 1'
+        colour: red
+        thickness: 0.7
+        linestyle: '-'
+        shifttime: +25.
+    u-cn618: 
+        description: 'GC5 N96 ORCA1 spin-up 2'
+        colour: blue
+        thickness: 0.7
+        linestyle: '-'
+        shifttime: 0.
+    u-cp416: 
+        description: 'GC5 N96 ORCA1 spin-up 3'
+        colour: purple
+        thickness: 0.7
+        linestyle: '-'
+        shifttime: -450.
+
+

--- a/input_yml/GC5N96ORCA1spinup.yml
+++ b/input_yml/GC5N96ORCA1spinup.yml
@@ -12,18 +12,21 @@ jobs:
         colour: red
         thickness: 0.7
         linestyle: '-'
-        shifttime: +25.
+        shifttime: 0.
+        suite: physics
     u-cn618: 
         description: 'GC5 N96 ORCA1 spin-up 2'
         colour: blue
         thickness: 0.7
         linestyle: '-'
         shifttime: 0.
+        suite: physics        
     u-cp416: 
         description: 'GC5 N96 ORCA1 spin-up 3'
         colour: purple
         thickness: 0.7
         linestyle: '-'
-        shifttime: -450.
+        shifttime: 0.
+        suite: physics        
 
 

--- a/input_yml/comparison_analysis_template.yml
+++ b/input_yml/comparison_analysis_template.yml
@@ -1,0 +1,26 @@
+---
+# GC5 N96 ORCA1 spinup analysis
+name: Template job
+
+# Run the single Job Analysis (analysis_timeseries)
+do_analysis_timeseries: False
+  # if True, it calls `analysis_timeseries jobID suite` using details provided here.
+
+# Job ID's suites as named by Rose/Cylc
+jobs:
+    u-aa001: 
+        description: 'Job number 1'
+        colour: red
+        thickness: 1. 
+        linestyle: '-'
+        shifttime: 0.
+        suite: physics
+    u-aa002: 
+        description: 'Job number 2' 
+        colour: blue
+        thickness: 1.0
+        linestyle: ':'
+        shifttime: 0.
+        suite: physics        
+
+


### PR DESCRIPTION
Based on #22 & also fixes #16.

This PR adds a new interface to the comparison report maker. It's a straightforward yaml file which should make it easy for non-experts to quickly generate HTML bgcval2 reports. 

The new interface is documented in the README.md. 

Outside of this major addition, this PR fixes:
- Removes huge backlog of old analyses in `analysis_compare.py` and replaces it with a new interface. (2000 lines deleted in `analysis_compare.py`)
- Replaces year0 string with shifttimes dictionairy in `analysis_compare.py`.
- Makes a single job analysis available as part of `analysis_compare`, so users don't need to run several scripts then `analysis_compare`.
- Many of the double parentheses print (`print((` statements which were introduced in the python2 to python 3 auto conversion. 
- Changes the path to working files (shelves and images) to ensure they don't overlap with BGC-val v1 paths. 
- Sets the debug analysis list to AMOC only.
- sets hardwired `html5` paths to `bgcval2/html5`, following the restructuring of the repository. 
- Fixes longstanding bug where timeseries analysis doesn't use the "standard" path.py location for its shelve out path. (which was hidden as it hardwired the path to be the same as in path.py)
- Adds recent changes from BGC-val v1 about new UKESM2 output. (ie `thetao` is now `thetao_con` and so on.
- Analysis__timeseries now saves shelves after every 10 new files, instead of every one new file.