### PR TITLE
try catching and giving more details about the OSError from h5py netcdf4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - load_with_exception
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - load_with_exception
+      - load_with_exception  # do run ffs
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - load_with_exception  # do run ffs
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/bgcval2/bgcvaltools/dataset.py
+++ b/bgcval2/bgcvaltools/dataset.py
@@ -24,6 +24,7 @@
 
 import numpy as np
 import netCDF4
+import h5py
 from sys import argv
 
 #####
@@ -41,9 +42,13 @@ class dataset:
         self.netcdfPath = filename
         self.filename = filename
         try:
-            self.dataset = netCDF4.Dataset(filename, 'r')
-        except:
-            print(("dataset:\tUnable to open", filename))
+            self.dataset = netCDF4.Dataset(filename, 'r', format='NETCDF4')
+        except OSError as oserr:
+            print("dataset:\tUnable to open %s - below more info", filename)
+            if oserr.errno == -101:
+                # https://stackoverflow.com/questions/49317927/errno-101-netcdf-hdf-error-when-opening-netcdf-file
+                print("Your filesystem may not support HDF5 locking")
+                print("Try setting HDF5_USE_FILE_LOCKING=FALSE")
             self.dataset = netCDF4.Dataset(
                 filename, 'r'
             )  # This is a ham fisted way to print the file name being loaded and the error message.

--- a/bgcval2/bgcvaltools/dataset.py
+++ b/bgcval2/bgcvaltools/dataset.py
@@ -42,7 +42,6 @@ class dataset:
         self.netcdfPath = filename
         self.filename = filename
         try:
-<<<<<<< HEAD
             self.dataset = netCDF4.Dataset(filename, 'r', format='NETCDF4')
         except OSError as oserr:
             print("dataset:\tUnable to open %s - below more info", filename)

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   # basic list of dependencies to be extended as we require packages
   - basemap
   - cartopy
+  - h5py
   - matplotlib
   - netcdf4
   - numpy

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ REQUIREMENTS = {
     'install': [
         'basemap',
         'cartopy',
+        'h5py',
         'matplotlib',
         'netcdf4',
         'numpy',


### PR DESCRIPTION
Closes #28 

So there may be two solutions to the problem in #28 - that's not a problem with the file but with the system (or, user's libraries):
- one way to fix it is to have netCDF4 imported before h5py
- another is to set `HDF5_USE_FILE_LOCKING=FALSE`

At any rate, one should be absolutely clear both netCDF4 and h5py are installed from conda-forge and I will double check this for our env 