### PR TITLE
Fix make report

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - fix_make_report
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - fix_make_report
   schedule:
     - cron: '0 0 * * *'  # nightly
 
@@ -41,6 +42,7 @@ jobs:
           analysis_level3_sameYear --help
           analysis_p2p --help
           analysis_timeseries --help
+          bgcval2_make_report --help
           bgcval --help           
       - shell: bash -l {0}
         run: pytest -n 2

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ analysis_p2p u-bc179 level2 2010
 Once these have completed, a summary HTML page can be generated with the command:
 
 ```
-makeReport u-bc179 2010
+bgcval2_make_report u-bc179 2010
 ```
 This produces an html5 mobile-friendly website which can be opened using your
 browser of choice.
@@ -69,7 +69,7 @@ Executable name | What it does | Command
 `analysis_timeseries` | runs timeseries analysis for single model run. | analysis_timeseries jobID key
 `analysis_p2p` | runs point to point analysis of model against observational dataset. | analysis_p2p jobID YEAR
 `bgcval` | runs time series and point to point. | bgcval jobID
-`makeReport` | makes the single model HTML report. | makeReport jobID
+`bgcval2_make_report` | makes the single model HTML report. | bgcval2_make_report jobID
 `analysis_compare` | runs comparison of multiple single jobs  | analysis_compare
 
 
@@ -124,7 +124,7 @@ Single Model report
 Once an analysis has run, either time series or point to point, a report
 can be generated from this output, using the command:
 ```
-makeReport jobID year
+bgcval2_make_report jobID year
 ```
 This  gnerated an HTML5 mobile-friendlyt report, summarising the output of a
 single model run.

--- a/bgcval2/Paths/paths.py
+++ b/bgcval2/Paths/paths.py
@@ -26,6 +26,7 @@
    :synopsis: A list of paths to data files.
 .. moduleauthor:: Lee de Mora <ledm@pml.ac.uk>
 """
+import os
 
 class paths():
     """Empty class to hold paths."""
@@ -33,6 +34,9 @@ class paths():
 
 def paths_setter(paths_dict):
     """Grab all paths and return them."""
+
+    paths_dir = os.path.dirname(os.path.realpath(__file__))
+    paths.bgcval2_repo = os.path.dirname(os.path.dirname(paths_dir))
     # [general] paths; mandatory everywhere
     paths.machinelocation = paths_dict["general"]["machinelocation"]
     paths.root_dir = paths_dict["general"]["root_dir"]

--- a/bgcval2/analysis_compare.py
+++ b/bgcval2/analysis_compare.py
@@ -173,7 +173,6 @@ def timeseries_compare(jobs,
 
     # filter paths dict into an object that's usable below
     paths = paths_setter(paths_dict)
- 
     if analysisname == '':
         print('ERROR: please provide an name for this analsys')
         sys.exit(0)

--- a/bgcval2/analysis_compare.py
+++ b/bgcval2/analysis_compare.py
@@ -173,7 +173,7 @@ def timeseries_compare(jobs,
 
     # filter paths dict into an object that's usable below
     paths = paths_setter(paths_dict)
-
+ 
     if analysisname == '':
         print('ERROR: please provide an name for this analsys')
         sys.exit(0)
@@ -2876,7 +2876,7 @@ def timeseries_compare(jobs,
                 nc.close()
 
                 # load basin mask
-                nc = Dataset('bgcval2/data/basinlandmask_eORCA1.nc', 'r')
+                nc = Dataset(os.path.join(paths.bgcval2_repo,'bgcval2/data/basinlandmask_eORCA1.nc'), 'r')
                 alttmask[name] = nc.variables['tmaskatl'][
                     latslice, :]  # 2D Atlantic mask
                 nc.close()
@@ -4015,6 +4015,7 @@ def timeseries_compare(jobs,
         doZip=False,
         jobDescriptions=jobDescriptions,
         jobColours=colours,
+        paths=paths,
     )
 
 

--- a/bgcval2/analysis_compare.py
+++ b/bgcval2/analysis_compare.py
@@ -66,7 +66,7 @@ except:
     from .pftnames import getLongName
 from .bgcvaltools.mergeMonthlyFiles import mergeMonthlyFiles, meanDJF
 from .netcdf_manipulation.alwaysInclude import alwaysInclude
-from .makeReport import comparehtml5Maker
+from .bgcval2_make_report import comparehtml5Maker
 #from .Paths import paths
 
 #from .comparison.shifttimes import shifttimes as shifttimes_legacy

--- a/bgcval2/analysis_timeseries.py
+++ b/bgcval2/analysis_timeseries.py
@@ -3465,7 +3465,7 @@ def analysis_timeseries(
         av[name]['model'] = 'NEMO'
 
         av[name]['modelgrid'] = 'eORCA1'
-        av[name]['gridFile'] = './data/eORCA1_gridU_mesh.nc'
+        av[name]['gridFile'] = os.path.join(paths.bgcval2_repo, 'bgcval2/data/eORCA1_gridU_mesh.nc')
         av[name]['Dimensions'] = 3
 
     if 'MeridionalCurrent' in analysisKeys:
@@ -3504,7 +3504,7 @@ def analysis_timeseries(
         av[name]['model'] = 'NEMO'
 
         av[name]['modelgrid'] = 'eORCA1'
-        av[name]['gridFile'] = './data/eORCA1_gridV_mesh.nc'
+        av[name]['gridFile'] = os.path.join(paths.bgcval2_repo, 'bgcval2/data/eORCA1_gridV_mesh.nc')
         av[name]['Dimensions'] = 3
 
     if 'VerticalCurrent' in analysisKeys:
@@ -3549,7 +3549,7 @@ def analysis_timeseries(
         av[name]['model'] = 'NEMO'
 
         av[name]['modelgrid'] = 'eORCA1'
-        av[name]['gridFile'] = './data/eORCA1_gridW_mesh.nc'
+        av[name]['gridFile'] = os.path.join(paths.bgcval2_repo, 'bgcval2/data/eORCA1_gridW_mesh.nc')
         av[name]['Dimensions'] = 3
 
     if 'WindStress' in analysisKeys:
@@ -3598,7 +3598,7 @@ def analysis_timeseries(
         av[name]['model'] = 'NEMO'
 
         av[name]['modelgrid'] = 'eORCA1'
-        av[name]['gridFile'] = './data/eORCA1_gridU_mesh.nc'
+        av[name]['gridFile'] = os.path.join(paths.bgcval2_repo, 'bgcval2./data/eORCA1_gridU_mesh.nc')
         av[name]['Dimensions'] = 2
 
     #####
@@ -4373,9 +4373,7 @@ def analysis_timeseries(
             nc.close()
 
             # load basin mask
-            basedir = os.path.dirname(__file__)
-            nc = dataset(os.path.join(basedir,
-                                      'data/basinlandmask_eORCA1.nc'), 'r')
+            nc = dataset(os.path.join(paths.bgcval2_repo, 'bgcval2/data/basinlandmask_eORCA1.nc'), 'r')
             alttmask[name] = nc.variables['tmaskatl'][
                 latslice, :]  # 2D Atlantic mask
             if name == [

--- a/bgcval2/bgcval.py
+++ b/bgcval2/bgcval.py
@@ -25,7 +25,7 @@
 #####
 #
 """
-.. module:: theWholePackage
+.. module:: bgcval
    :platform: Unix
    :synopsis: A script the run the entire suite of analyses and produce an html report.
 .. moduleauthor:: Lee de Mora <ledm@pml.ac.uk>
@@ -42,7 +42,7 @@ from .bgcvaltools.downloadFromMass import downloadMass, findLastFinishedYear
 from .analysis_timeseries import analysis_timeseries, singleTimeSeries, singleTimeSeriesProfile
 from .analysis_timeseries import level1KeysDict, physKeysDict, bgcKeysDict, keymetricsfirstDict
 from .analysis_p2p import analysis_p2p, p2pDict_level2, p2pDict_physics, single_p2p
-from .makeReport import html5Maker
+from .bgcval2_make_report import html5Maker
 from .UKESMpython import folder
 
 

--- a/bgcval2/bgcval2_make_report.py
+++ b/bgcval2/bgcval2_make_report.py
@@ -30,6 +30,8 @@
 
 #####
 # Load Standard Python modules:
+import sys
+
 from glob import glob
 from sys import argv
 import os

--- a/bgcval2/bgcval2_make_report.py
+++ b/bgcval2/bgcval2_make_report.py
@@ -132,7 +132,7 @@ def html5Maker(
     # Copy all necceasiry objects and templates to the report location:
     print("Copying html and js assets to", reportdir)
     basedir = os.path.dirname(__file__)
-    copytree(os.path.join(basedir, 'bgcval2/html5/html5Assets'), reportdir)
+    copytree(os.path.join(basedir, os.path.join(paths.bgcval2_repo,'bgcval2/html5/html5Assets')), reportdir)
     indexhtmlfn = reportdir + "index.html"
     try:
         os.rename(reportdir + 'index-template.html', indexhtmlfn)
@@ -1312,7 +1312,7 @@ def html5Maker(
 
     if regionMap:
         vfiles = []
-        vfiles.extend(glob('bgcval2/html5/html5Assets/images/*Legend*.png'))
+        vfiles.extend(glob(os.path.join(paths.bgcval2_repo,'bgcval2/html5/html5Assets/images/*Legend*.png')))
         print('adding Legend')
 
         relfns = [addImageToHtml(fn, imagesfold, reportdir) for fn in vfiles]
@@ -1349,13 +1349,14 @@ def html5Maker(
 
 
 def comparehtml5Maker(
-    jobIDs=['u-ab749', 'u-ad371'],
+    jobIDs=[],
     reportdir='reports/tmp',
     files=[],
     clean=False,
     doZip=False,
     jobDescriptions={},
     jobColours={},
+    paths = {}
 ):
 
     if clean:
@@ -1372,7 +1373,9 @@ def comparehtml5Maker(
     ####
     # Copy all necceasiry objects and templates to the report location:
     print("Copying html and js assets to", reportdir)
-    copytree('bgcval2/html5/html5Assets', reportdir)
+    #html5Assets_dir = 
+
+    copytree(os.path.join(paths.bgcval2_repo,'bgcval2/html5/html5Assets'), reportdir)
     indexhtmlfn = reportdir + "index.html"
     try:
         os.rename(reportdir + 'index-compare-template.html', indexhtmlfn)
@@ -1691,7 +1694,7 @@ def comparehtml5Maker(
     legend = True
     if legend:
         vfiles = []
-        vfiles.extend(glob('bgcval2/html5/html5Assets/images/*Legend*.png'))
+        vfiles.extend(glob(os.path.join(paths.bgcval2_repo,'bgcval2/html5/html5Assets/images/*Legend*.png')))
         print('Adding compare plots legend')
         relfns = [addImageToHtml(fn, imagesfold, reportdir) for fn in vfiles]
         print(relfns)

--- a/bgcval2/bgcval2_make_report.py
+++ b/bgcval2/bgcval2_make_report.py
@@ -21,7 +21,7 @@
 # Email:
 # ledm@pml.ac.uk
 """
-.. module:: makeReport
+.. module:: bgcval2_make_report
    :platform: Unix
    :synopsis: A script to produce an html5 document summarising a jobs performance.
 .. moduleauthor:: Lee de Mora <ledm@pml.ac.uk>
@@ -1766,7 +1766,7 @@ def main():
     config_user = None
     if "bgcval2-config-user.yml" in argv[1:]:
         config_user = "bgcval2-config-user.yml"
-        print(f"makeReport: Using user config file {config_user}")
+        print(f"bgcval2_make_report: Using user config file {config_user}")
     if config_user:
         paths_dict, config_user = get_run_configuration(config_user)
     else:

--- a/bgcval2/bgcval2_make_report.py
+++ b/bgcval2/bgcval2_make_report.py
@@ -1721,7 +1721,7 @@ def comparehtml5Maker(
 
 
 def main():
-    """Run the html meat."""
+    """Run the html maker for a single job ID."""
     from ._version import __version__
     print(f'BGCVal2: {__version__}')
     if "--help" in argv or len(argv) == 1:

--- a/bgcval2/check_basic_run.sh
+++ b/bgcval2/check_basic_run.sh
@@ -6,5 +6,5 @@ python analysis_level3_sameYear.py
 python analysis_p2p.py
 python analysis_timeseries.py
 python conf.py
-python makeReport.py
+python bgcval2_make_report.py
 python theWholePackage.py

--- a/bgcval2/html5/html5Tools.py
+++ b/bgcval2/html5/html5Tools.py
@@ -36,7 +36,7 @@ from ..bgcvaltools.pftnames import getLongName
 
 def get_this_file(html5_file):
     """
-    gets the correct to a specific file in html5.
+    gets the correct path to a specific file in html5.
     """
     return os.path.join(os.path.dirname(__file__), html5_file)
 

--- a/bgcval2/html5/html5Tools.py
+++ b/bgcval2/html5/html5Tools.py
@@ -33,6 +33,14 @@ import os
 from ..bgcvaltools.pftnames import getLongName
 
 
+
+def get_this_file(html5_file):
+    """
+    gets the correct to a specific file in html5.
+    """
+    return os.path.join(os.path.dirname(__file__), html5_file)
+
+
 def AddtoFile(filepath, linenumber, text):
     """	Adds "text" at line "linenumber" in the file "filepath"
 	"""
@@ -163,7 +171,7 @@ def AddSection(filepath, href, Title, Description='', Files=[]):
 
     #####
     # Copy the template and add the images.
-    f = open("bgcval2/html5/section-template.html", "r")
+    f = open(get_this_file("section-template.html"), "r")
     contents = f.readlines()
     f.close()
     if type(Files) == type([

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ setup(
             'analysis_p2p = bgcval2.analysis_p2p:run',
             'analysis_timeseries = bgcval2.analysis_timeseries:main',
             'bgcval = bgcval2.bgcval:run',
-            'makeReport = bgcval2.makeReport:main',
+            'bgcval2_make_report = bgcval2.bgcval2_make_report:main',
         ],
     },
     cmdclass={


### PR DESCRIPTION
Fixes the report maker so that it can work from any location. To do this, I've added the repository base directory to paths as paths.bgcval2_repo.

Closes #12 

Change log:

- Changed `makeReport.py` to `bgcval2_make_report.py` (start of addressing #18.)
- Changed several hard-wired relative paths to absolute paths relative to `paths.bgcval2_repo`

