### PR TITLE
Pin nctoolkit to use linux64 build rather than noarch

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - pin-nctoolkit
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - pin-nctoolkit
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - basemap>=1.3.6
   - cartopy
   - matplotlib
-  - nctoolkit
+  - nctoolkit >=0.8.7  # use linux64 build
   - netcdf4
   - numpy
   - pip!=21.3

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ REQUIREMENTS = {
         'basemap>=1.3.6',
         'cartopy',
         'matplotlib',
-        'netcdf4!=1.6.1',  # https://github.com/ESMValGroup/ESMValCore/pull/1724
+        'nctoolkit>=0.8.7',  # use linux64 build
+        'netcdf4',
         'numpy',
         'pip!=21.3',
         'pyyaml',


### PR DESCRIPTION
`nctoolkit` is starting to behave odd for the latest python=3.10 and 3.11 - the `noarch` build is picked up (0.2.2) by mamba and that's problematic; see [failed test](https://github.com/valeriupredoi/bgcval2/actions/runs/4277883420/jobs/7447084817)