### PR TITLE
drop support for python=3.8

### DIFF
--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v1
         with:
           python-version: "3.11"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This work was funded through WP1 of the Terrafirma project.
 
 Current version notes:
 
-- Suport for the latest version Python 3.11 is now **enabled**.
+- Suported versions of Python: 3.9, 3.10 and 3.11
 
 Environment and installation
 ============================

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - netcdf4
   - numpy
   - pip!=21.3
-  - python>=3.8
+  - python>=3.9
   - pyyaml
   - scipy
   - scikit-learn
@@ -36,7 +36,6 @@ dependencies:
   - docformatter
   - isort
   - pre-commit
-  # prospector still doesn't support Python=3.11 (24/02/2023)
-  # - prospector!=1.1.6.3,!=1.1.6.4
+  - prospector >=1.9.0
   - yamllint
   - yapf

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ REQUIREMENTS = {
     # Test dependencies
     # Execute 'python setup.py test' to run tests
     'test': [
-        'flake8<4',
+        'flake8',
         'pytest>=3.9,!=6.0.0rc1,!=6.0.0',
         'pytest-cov>=2.10.1',
         'pytest-env',

--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,7 @@ REQUIREMENTS = {
         'docformatter',
         'isort',
         'pre-commit',
-        # prospector still doesn't support Python=3.11 (24/02/2023)
-        # 'prospector[with_pyroma,with_mypy]!=1.1.6.3,!=1.1.6.4',
+        'prospector[with_pyroma,with_mypy]>=1.9.0',
         'sphinx>2',
         'sphinx_rtd_theme',
         'vprof',
@@ -176,6 +175,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Atmospheric Science',
         'Topic :: Scientific/Engineering :: GIS',


### PR DESCRIPTION
[NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) motivates a drop of support for Python=3.8