### PR TITLE
Cleanup environment and pin numpy so that it installs from conda-forge

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - cleanup_env_numpy_from_condaforge
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - cleanup_env_numpy_from_condaforge
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,15 +10,15 @@ dependencies:
   - matplotlib
   - nctoolkit >=0.8.7  # use linux64 build
   - netcdf4
-  - numpy !=1.24.3
+  - numpy >1.24.3, <1.25  # basemap=1.3.7 needs <1.25
   - pip !=21.3
   - python >=3.9
   - pyyaml
-  - scipy
+  - scipy >=1.6
   - scikit-learn
   # Python packages - dependencies for testing
   - flake8
-  - iris
+  - iris >=3.4.0
   - pytest >=3.9,!=6.0.0rc1,!=6.0.0
   - pytest-cov >=2.10.1
   - pytest-env

--- a/setup.py
+++ b/setup.py
@@ -29,20 +29,20 @@ REQUIREMENTS = {
         'matplotlib',
         'nctoolkit>=0.8.7',  # use linux64 build
         'netcdf4',
-        'numpy!=1.24.3',
+        'numpy>1.24.3,<1.25',  # basemap 1.3.7 needs <1.25
         'pip!=21.3',
         'pyyaml',
         'scikit-learn',
-        'scipy',
+        'scipy>=1.6',
     ],
     # Test dependencies
     # Execute 'python setup.py test' to run tests
     'test': [
         'flake8',
+        'scitools-iris>=3.4.0',
         'pytest>=3.9,!=6.0.0rc1,!=6.0.0',
         'pytest-cov>=2.10.1',
         'pytest-env',
-        'pytest-flake8>=1.0.6',
         'pytest-html!=2.1.0',
         'pytest-metadata>=1.5.1',
         'pytest-mypy',
@@ -58,7 +58,7 @@ REQUIREMENTS = {
         'isort',
         'pre-commit',
         'prospector[with_pyroma,with_mypy]>=1.9.0',
-        'sphinx>2',
+        'sphinx>=5',
         'sphinx_rtd_theme',
         'vprof',
         'yamllint',


### PR DESCRIPTION
The mamba env contains `numpy=1.25.2` that is rejected by `basemap=1.3.7` via `pip install` so pip installs `numpy=1.24.4` from PyPI which we don't want, we want the same version of numpy but from conda-forge. It is unclear if `basemap` has a soft dependency in its dep table, mamba should not install 1.25.2 if another package rejects it.

Closes #108 