### PR TITLE
Fix auto download permissions

### DIFF
--- a/bgcval2/download_from_mass.py
+++ b/bgcval2/download_from_mass.py
@@ -37,6 +37,7 @@ import subprocess
 from socket import gethostname
 import shutil
 import os
+from pwd import getpwuid
 import stat
 from glob import glob
 from re import findall
@@ -409,7 +410,16 @@ def download_from_mass(
     outputFold = folder([paths.ModelFolder_pref,  jobID,] )
     # make this folder group writeable. 
     st = os.stat(outputFold)
-    os.chmod(outputFold, st.st_mode | stat.S_IWGRP)
+    
+    # Case one:
+    # I just created this folder and I own it: 
+    i_can_write_this = os.access(outputFold, os.W_OK)
+    if i_can_write_this:
+        os.chmod(outputFold, st.st_mode | stat.S_IWGRP)
+    else:
+        uname = getpwuid(os.stat(outputFold).st_uid).pw_name
+        print('WARNING: someone else (', uname, ') owns this directory, so you may not be able to download files.')
+        print('WARNING: Ask them politely to run "chmod g+w ',outputFold,'"')
 
     deleteBadLinksAndZeroSize(outputFold, jobID)
 
@@ -483,8 +493,19 @@ def download_from_mass(
     if auto_download:
         shared_file_path = os.path.join(paths.shared_mass_scripts, os.path.basename(download_script_path))
         print('writing file in shared path', shared_file_path)
-        shutil.copy(download_script_path, shared_file_path)
 
+        # Case one:
+        # I just created this folder and I own it:
+        i_can_write_this = os.access(shared_file_path, os.W_OK)
+        if i_can_write_this:
+            os.chmod(download_script_path, st.st_mode | stat.S_IWGRP)
+            shutil.copy(download_script_path, shared_file_path)
+            os.chmod(shared_file_path, st.st_mode | stat.S_IWGRP)
+        else:
+            uname = getpwuid(os.stat(shared_file_path).st_uid).pw_name
+            print('WARNING: someone else (', shared_file_path, ') owns this directory, so you may not be able to download files.')
+            print('WARNING: Ask them politely to run "chmod g+w ', shared_file_path,'"')
+        
     fixFilePaths(outputFold, jobID, debug=False,)
     deleteBadLinksAndZeroSize(outputFold, jobID, debug=False,)
 
@@ -598,12 +619,17 @@ def deleteBadLinksAndZeroSize(outputFold, jobID, debug=True):
     bashCommand1 = "find " + outputFold + "/. -size 0 -print -delete"
     bashCommand2 = "find -L " + outputFold + "/. -type l -delete  -print"
 
-    if debug: print("deleteBadLinksAndZeroSize:\t", bashCommand1)
+    bashCommand1 = bashCommand1.replace('//', '/')
+    bashCommand2 = bashCommand2.replace('//', '/')
+
+    #f debug: 
+    print("deleteBadLinksAndZeroSize:\t", bashCommand1)
 
     process1 = subprocess.Popen(bashCommand1.split(), stdout=subprocess.PIPE)
     output1 = process1.communicate()[0]
 
-    if debug: print("deleteBadLinksAndZeroSize:\t", bashCommand2)
+    #f debug: 
+    print("deleteBadLinksAndZeroSize:\t", bashCommand2)
 
     process2 = subprocess.Popen(bashCommand2.split(), stdout=subprocess.PIPE)
     output2 = process2.communicate()[0]

--- a/bgcval2/download_from_mass.py
+++ b/bgcval2/download_from_mass.py
@@ -412,7 +412,7 @@ def download_from_mass(
     st = os.stat(outputFold)
     
     # Case one:
-    # I just created this folder and I own it: 
+    # I created this folder and I own it: 
     i_can_write_this = os.access(outputFold, os.W_OK)
     if i_can_write_this:
         os.chmod(outputFold, st.st_mode | stat.S_IWGRP)
@@ -494,8 +494,7 @@ def download_from_mass(
         shared_file_path = os.path.join(paths.shared_mass_scripts, os.path.basename(download_script_path))
         print('writing file in shared path', shared_file_path)
 
-        # Case one:
-        # I just created this folder and I own it:
+        # I created this file and I own it:
         i_can_write_this = os.access(shared_file_path, os.W_OK)
         if i_can_write_this:
             os.chmod(download_script_path, st.st_mode | stat.S_IWGRP)

--- a/bgcval2/download_from_mass.py
+++ b/bgcval2/download_from_mass.py
@@ -409,7 +409,7 @@ def download_from_mass(
     paths = get_paths(config_user)
     outputFold = folder([paths.ModelFolder_pref,  jobID,] )
     st = os.stat(outputFold)
-   
+
     # Check permissions on the output folder 
     i_can_write_this = os.access(outputFold, os.W_OK)
     if i_can_write_this:

--- a/bgcval2/download_from_mass.py
+++ b/bgcval2/download_from_mass.py
@@ -408,16 +408,18 @@ def download_from_mass(
 
     paths = get_paths(config_user)
     outputFold = folder([paths.ModelFolder_pref,  jobID,] )
-    # make this folder group writeable. 
     st = os.stat(outputFold)
-    
-    # Case one:
-    # I created this folder and I own it: 
+   
+    # Check permissions on the output folder 
     i_can_write_this = os.access(outputFold, os.W_OK)
     if i_can_write_this:
+        # I created this folder and I own it.
+        # make this folder group writeable.
         os.chmod(outputFold, st.st_mode | stat.S_IWGRP)
     else:
-        uname = getpwuid(os.stat(outputFold).st_uid).pw_name
+        # Someone else created it and they own it,
+        # so I can't change permissions.
+        uname = getpwuid(st.st_uid).pw_name
         print('WARNING: someone else (', uname, ') owns this directory, so you may not be able to download files.')
         print('WARNING: Ask them politely to run "chmod g+w ',outputFold,'"')
 
@@ -494,13 +496,20 @@ def download_from_mass(
         shared_file_path = os.path.join(paths.shared_mass_scripts, os.path.basename(download_script_path))
         print('writing file in shared path', shared_file_path)
 
-        # I created this file and I own it:
+        # check destination permissions:
         i_can_write_this = os.access(shared_file_path, os.W_OK)
         if i_can_write_this:
+            # I created this file and I own it:
+            # make local copy group writable:
             os.chmod(download_script_path, st.st_mode | stat.S_IWGRP)
+           
+            # copy local to shared folder: 
             shutil.copy(download_script_path, shared_file_path)
+
+            # make shared copy group writable: (possibly overkill)
             os.chmod(shared_file_path, st.st_mode | stat.S_IWGRP)
         else:
+            # I don't have permission to edit this file. Someone else does:
             uname = getpwuid(os.stat(shared_file_path).st_uid).pw_name
             print('WARNING: someone else (', shared_file_path, ') owns this directory, so you may not be able to download files.')
             print('WARNING: Ask them politely to run "chmod g+w ', shared_file_path,'"')
@@ -621,15 +630,11 @@ def deleteBadLinksAndZeroSize(outputFold, jobID, debug=True):
     bashCommand1 = bashCommand1.replace('//', '/')
     bashCommand2 = bashCommand2.replace('//', '/')
 
-    #f debug: 
     print("deleteBadLinksAndZeroSize:\t", bashCommand1)
-
     process1 = subprocess.Popen(bashCommand1.split(), stdout=subprocess.PIPE)
     output1 = process1.communicate()[0]
 
-    #f debug: 
     print("deleteBadLinksAndZeroSize:\t", bashCommand2)
-
     process2 = subprocess.Popen(bashCommand2.split(), stdout=subprocess.PIPE)
     output2 = process2.communicate()[0]
 

--- a/tests/unit/test_download_from_mass_permissions.py
+++ b/tests/unit/test_download_from_mass_permissions.py
@@ -16,7 +16,11 @@ def test_allowed_user():
         auto_download=False,
         config_user="defaults"
     )
-    assert os.stat(run_dir).st_mode == 16893
+    try:
+        assert os.stat(run_dir).st_mode == 16893
+    # when stat mode is 16877 (equivalent to chmod 877)
+    except AssertionError:
+        assert os.stat(run_dir).st_mode == 16877
 
 
 def test_disallowed_user():

--- a/tests/unit/test_download_from_mass_permissions.py
+++ b/tests/unit/test_download_from_mass_permissions.py
@@ -6,14 +6,16 @@ from bgcval2.download_from_mass import download_from_mass as dfm
 
 
 def test_allowed_user():
+    user_home = os.path.expanduser('~')
+    output_folder = "bgcval2/local_test/BGC_data/u-xxx/"
+    run_dir = os.path.join(user_home, output_folder)
+    if not os.path.exists(run_dir):
+        os.makedirs(run_dir)
     dfm(jobID="u-xxx",
         doMoo=False,
         auto_download=False,
         config_user="defaults"
     )
-    user_home = os.path.expanduser('~')
-    output_folder = "bgcval2/local_test/BGC_data/u-xxx/"
-    run_dir = os.path.join(user_home, output_folder)
     assert os.stat(run_dir).st_mode == 16893
 
 

--- a/tests/unit/test_download_from_mass_permissions.py
+++ b/tests/unit/test_download_from_mass_permissions.py
@@ -1,0 +1,32 @@
+import os
+import shutil
+import stat
+
+from bgcval2.download_from_mass import download_from_mass as dfm
+
+
+def test_allowed_user():
+    dfm(jobID="u-xxx",
+        doMoo=False,
+        auto_download=False,
+        config_user="defaults"
+    )
+    user_home = os.path.expanduser('~')
+    output_folder = "bgcval2/local_test/BGC_data/u-xxx/"
+    run_dir = os.path.join(user_home, output_folder)
+    assert os.stat(run_dir).st_mode == 16893
+
+
+def test_disallowed_user():
+    user_home = os.path.expanduser('~')
+    output_folder = "bgcval2/local_test/BGC_data/u-xxx/"
+    run_dir = os.path.join(user_home, output_folder)
+    st = os.stat(run_dir)
+    os.chmod(run_dir, False)
+    dfm(jobID="u-xxx",
+        doMoo=False,
+        auto_download=False,
+        config_user="defaults"
+    )
+    assert os.stat(run_dir).st_mode == 16384
+    shutil.rmtree(run_dir, ignore_errors=True)

--- a/tests/unit/test_download_from_mass_permissions.py
+++ b/tests/unit/test_download_from_mass_permissions.py
@@ -19,11 +19,13 @@ def test_allowed_user():
 
 def test_disallowed_user():
     user_home = os.path.expanduser('~')
-    output_folder = "bgcval2/local_test/BGC_data/u-xxx/"
+    output_folder = "bgcval2/local_test/BGC_data/u-yyy/"
     run_dir = os.path.join(user_home, output_folder)
+    if not os.path.exists(run_dir):
+        os.makedirs(run_dir)
     st = os.stat(run_dir)
     os.chmod(run_dir, False)
-    dfm(jobID="u-xxx",
+    dfm(jobID="u-yyy",
         doMoo=False,
         auto_download=False,
         config_user="defaults"


### PR DESCRIPTION
#closes 111 

This is for @DrYool.

Now bgcval2 checks whether you have write permission before attempting to overwrite the download script or change the download directory permissions. 

There are two places on jasmin that this affects:
- The destination for the files (ie `/gws/nopw/j04/ukesm/BGC_data/`)
- The auto-download script, (ie : `/gws/nopw/j04/esmeval/bgcval2/shared_mass_scripts/`)

I've tested it with the job `u-cq053` that @DrYool owns and it works fine for me. 

So now, once this is merged and everyone uses it, this should not longer break if someone else has already downloaded the job that you want to study.

`download_from_mass`  will now spit out a warning saying:
```
WARNING: someone else ( ayool ) owns this directory, so you may not be able to download files.
WARNING: Ask them politely to run "chmod g+w  /gws/nopw/j04/ukesm/BGC_data/u-cq053/ "
```

Things that are uncertain:
- This only changes permissions on active jobIDs. It won't go back and change old jobs - we should do that manually.
- The download is still down by my user account (automated with special permission from jasmin folks), so it's not clear how that affects the data files. 

So just as a reminder:
- if someone else has downloaded the data, you can still access it.
- if someone else has recently investigated a job, then if will be added to the auto-download list, and fresh data should appear overnight. 
- if you can't wait that long, you can manually download data on the mass-cli1 machine using the command:
  -    `download_from_mass -j u-aa111 jobID2 jobID3`
  
To test this:
```
git fetch
git merge remotes/origin/fix_auto_download_permissions
analysis_compare -y input/yml
```
