### PR TITLE
Bug fix for jobs with multiple grids in the same file. 

### DIFF
--- a/bgcval2/functions/globalVolMean.py
+++ b/bgcval2/functions/globalVolMean.py
@@ -33,14 +33,6 @@ import numpy as np
 from bgcval2.functions.standard_functions import choose_best_var 
 from bgcval2.functions.standard_functions import find_best_var
 
-#def calc_vol(nc):
-#    """
-#    Calculate volume from the (grid-T) netcdf file.
-#    """
-#    area = nc.variables['area'][:]
-#    thkcello = nc.variables['thkcello'][:]
-#    area = area[None, None,:, :]
-#    return thkcello * area
 
 def calc_vol(nc):
     """
@@ -52,6 +44,7 @@ def calc_vol(nc):
     thkcello = nc.variables[thkcello_key][:]
     area = area[None, None,:, :]
     return thkcello * area
+
 
 def globalVolumeMean(nc, keys, **kwargs):
     """


### PR DESCRIPTION
So, there are a bunch of NEMO jobs with data in the wrong file.
```
 ncdump -h /gws/nopw/j04/ukesm/BGC_data/u-ct598/nemo_ct598o_1y_19811201-19821201_grid-T.nc | grep 'area'
        float area_grid_T(y_grid_T, x_grid_T) ;
                area_grid_T:standard_name = "cell_area" ;
                area_grid_T:units = "m2" ;
        float area_grid_W(y_grid_W, x_grid_W) ;
                area_grid_W:standard_name = "cell_area" ;
                area_grid_W:units = "m2" ;
```
Basically, someone added data from two different grids to this file, so it has to include both grid definitions. It also has two sets of nav_lat and nav_lon. Instead of failing at run time, and outputting an error message, crazily NEMO allows this and it messes with everything at the output stage. It's a broken NEMO system and it was set up incorrectly. 

It outputs the error:
```
  File "/home/users/ayool/miniconda3/envs/bgcval2/bin/analysis_compare", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/users/ayool/bgcval2/bgcval2/analysis_compare.py", line 688, in main
    load_yml_and_run(compare_yml, config_user, skip_timeseries)
  File "/home/users/ayool/bgcval2/bgcval2/analysis_compare.py", line 603, in load_yml_and_run
    analysis_timeseries(
  File "/home/users/ayool/bgcval2/bgcval2/analysis_timeseries.py", line 687, in analysis_timeseries
    tsa = timeseriesAnalysis(
          ^^^^^^^^^^^^^^^^^^^
  File "/home/users/ayool/bgcval2/bgcval2/timeseries/timeseriesAnalysis.py", line 121, in __init__
    self.loadModel()
  File "/home/users/ayool/bgcval2/bgcval2/timeseries/timeseriesAnalysis.py", line 262, in loadModel
    DL = tst.DataLoader(
         ^^^^^^^^^^^^^^^
  File "/home/users/ayool/bgcval2/bgcval2/timeseries/timeseriesTools.py", line 280, in __init__
    if data == '': data = std_extractData(nc, self.details)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/users/ayool/bgcval2/bgcval2/functions/standard_functions.py", line 62, in extractData
    xd = details['convert'](nc,details['vars'], **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/users/ayool/bgcval2/bgcval2/functions/globalVolMean.py", line 62, in globalVolumeMean
    volume = calc_vol(nc)
             ^^^^^^^^^^^^
  File "/home/users/ayool/bgcval2/bgcval2/functions/globalVolMean.py", line 40, in calc_vol
    area = nc.variables['area'][:]
           ~~~~~~~~~~~~^^^^^^^^
KeyError: 'area'
```

This patch solves this problem.
