### PR TITLE
Added a new subpolar North Atlantic region (SPNA)

### DIFF
--- a/bgcval2/bgcvaltools/makeMask.py
+++ b/bgcval2/bgcvaltools/makeMask.py
@@ -245,6 +245,12 @@ def makeMask(name, newSlice, xt, xz, xy, xx, xd, debug=False):
             xy, 60., 80.).mask
         return mx
 
+    if newSlice in ['SubpolarNorthAtlantic', 'SPNA',]:
+        #  Based on  SPNA region here: https://www.nature.com/articles/s43247-021-00120-y#citeas
+        mx = np.ma.masked_outside(xx, -35., -10.).mask + np.ma.masked_outside(
+            xy, 40., 65.).mask
+        return mx
+    
     if newSlice == 'AtlanticSOcean':
         mx = np.ma.masked_outside(xx, -40., 20.).mask + np.ma.masked_outside(
             xy, -50., -75.).mask

--- a/bgcval2/bgcvaltools/pftnames.py
+++ b/bgcval2/bgcvaltools/pftnames.py
@@ -527,6 +527,8 @@ def makeLongNameDict():
     lnd['Remainder'] = "Oligotrophic Gyres"
     lnd['ArcticOcean'] = "Arctic Ocean"
     lnd['NorthernSubpolarAtlantic'] = "Northern Subpolar Atlantic"
+    lnd['SPNA'] = "Subpolar North Atlantic"
+    lnd['SubpolarNorthAtlantic'] =  lnd['SPNA']
     lnd['NorthernSubpolarPacific'] = "Northern Subpolar Pacific"
 
     lnd['SouthernOcean'] = "Southern Ocean"

--- a/bgcval2/timeseries/timeseriesAnalysis.py
+++ b/bgcval2/timeseries/timeseriesAnalysis.py
@@ -272,7 +272,8 @@ class timeseriesAnalysis:
                 self.modeldetails,
                 regions=self.regions,
                 layers=self.layers,
-                modeldataD=self.modeldataD,
+                metrics= self.metrics,
+                modeldataD=modeldataD,
             )
 
             for l in self.layers:

--- a/bgcval2/timeseries/timeseriesAnalysis.py
+++ b/bgcval2/timeseries/timeseriesAnalysis.py
@@ -274,6 +274,7 @@ class timeseriesAnalysis:
                 layers=self.layers,
                 metrics= self.metrics,
                 modeldataD=modeldataD,
+                meantime=meantime,
             )
 
             for l in self.layers:

--- a/bgcval2/timeseries/timeseriesAnalysis.py
+++ b/bgcval2/timeseries/timeseriesAnalysis.py
@@ -272,6 +272,7 @@ class timeseriesAnalysis:
                 self.modeldetails,
                 regions=self.regions,
                 layers=self.layers,
+                modeldataD=self.modeldataD,
             )
 
             for l in self.layers:

--- a/bgcval2/timeseries/timeseriesTools.py
+++ b/bgcval2/timeseries/timeseriesTools.py
@@ -324,8 +324,8 @@ class DataLoader:
 
             for region in self.regions:
                 loadthisregion = 0
-                for m in metrics:
-                    if self.modeldataD.get((r, l, m), False) and self.meantime in modeldataD[(r, l, m)]:
+                for m in self.metrics:
+                    if self.modeldataD.get((region, l, m), False) and self.meantime in self.modeldataD[(region, l, m)]:
                         # Data arra already exists and This time point's data already exists                         
                         continue
                     # This region does not exist in the processed data, so add it.

--- a/bgcval2/timeseries/timeseriesTools.py
+++ b/bgcval2/timeseries/timeseriesTools.py
@@ -267,6 +267,9 @@ class DataLoader:
                  layers=[
                      'Surface',
                  ],
+                 modeldataD = {},
+                 metrics = ['mean', ],
+                 meantime = 0,
                  data=''):
         self.fn = fn
         if type(nc) == type('filename'):
@@ -276,6 +279,9 @@ class DataLoader:
         self.details = details
         self.regions = regions
         self.layers = layers
+        self.metrics = metrics
+        self.modeldataD = modeldataD
+        self.meantime = meantime
         self.name = self.details['name']
         if data == '': data = std_extractData(nc, self.details)
         self.Fulldata = data
@@ -294,7 +300,7 @@ class DataLoader:
             depths = {}
         lays = self.layers[:]
         lays.reverse()
-
+               
         for l in lays:
             try:
                 layer = int(l)
@@ -317,6 +323,15 @@ class DataLoader:
                 continue
 
             for region in self.regions:
+                loadthisregion = 0
+                for m in metrics:
+                    if self.modeldataD.get((r, l, m), False) and self.meantime in modeldataD[(r, l, m)]:
+                        # Data arra already exists and This time point's data already exists                         
+                        continue
+                    # This region does not exist in the processed data, so add it.
+                    loadthisregion +=1
+                if loadthisregion == 0:
+                    continue
                 arr, arr_t, arr_z, arr_lat, arr_lon = self.createDataArray(
                     region, layer)
                 if len(arr) == 0:

--- a/bgcval2/timeseries/timeseriesTools.py
+++ b/bgcval2/timeseries/timeseriesTools.py
@@ -355,16 +355,6 @@ class DataLoader:
                 print('{:<24} layer: {:<8}'.format(region, layer), end=' ')
                 print('\tdata length:',
                       len(self.load[(region, layer)]),)
-                      #end=' ')
-                #print('\tmean:',
-                #      self.load[(region, layer)].mean(),
-                #      'of',
-                #      len(self.load[(region, layer)]),
-                #      end=' ')
-                #print('\trange:', [
-                #    self.load[(region, layer)].min(),
-                #    self.load[(region, layer)].max()
-                #])
 
     def _makeTimeDict_(self, ):
         """ Make a dictionairy linking the time index with the float time.

--- a/bgcval2/timeseries/timeseriesTools.py
+++ b/bgcval2/timeseries/timeseriesTools.py
@@ -336,17 +336,17 @@ class DataLoader:
                 print("DataLoader:\tLoaded", self.name, 'in', end=' ')
                 print('{:<24} layer: {:<8}'.format(region, layer), end=' ')
                 print('\tdata length:',
-                      len(self.load[(region, layer)]),
-                      end=' ')
-                print('\tmean:',
-                      self.load[(region, layer)].mean(),
-                      'of',
-                      len(self.load[(region, layer)]),
-                      end=' ')
-                print('\trange:', [
-                    self.load[(region, layer)].min(),
-                    self.load[(region, layer)].max()
-                ])
+                      len(self.load[(region, layer)]),)
+                      #end=' ')
+                #print('\tmean:',
+                #      self.load[(region, layer)].mean(),
+                #      'of',
+                #      len(self.load[(region, layer)]),
+                #      end=' ')
+                #print('\trange:', [
+                #    self.load[(region, layer)].min(),
+                #    self.load[(region, layer)].max()
+                #])
 
     def _makeTimeDict_(self, ):
         """ Make a dictionairy linking the time index with the float time.

--- a/bgcval2/timeseries/timeseriesTools.py
+++ b/bgcval2/timeseries/timeseriesTools.py
@@ -327,7 +327,10 @@ class DataLoader:
                 for m in self.metrics:
                     if self.modeldataD.get((region, l, m), False) and self.meantime in self.modeldataD[(region, l, m)]:
                         # Data arra already exists and This time point's data already exists                         
+                        print('Dataloader: No need to load this setting', (region, l, m))
                         continue
+                    print('Dataloader: We need to re-load this setting', (region, l, m), self.meantime)
+
                     # This region does not exist in the processed data, so add it.
                     loadthisregion +=1
                 if loadthisregion == 0:

--- a/key_files/alkalinity.yml
+++ b/key_files/alkalinity.yml
@@ -19,5 +19,5 @@ model_convert   : NoChange
 #    function: convertmeqm3TOumolkg
 
 layers          : Surface #50m #;100m 200m 500m 1000m 2000m
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 
 

--- a/key_files/atmospco2.yml
+++ b/key_files/atmospco2.yml
@@ -8,7 +8,7 @@ modelFiles      : $BASEDIR_MODEL/$JOBID/medusa*$JOBIDo_1y_*_diad-T.nc
 model_vars      : ATM_PCO2
 model_convert   : NoChange
 layers          : layerless
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 
 
 
 

--- a/key_files/chlorophyll.yml
+++ b/key_files/chlorophyll.yml
@@ -14,7 +14,7 @@ model_vars      : CHD CHN
 model_convert   : sum
 
 layers          : Surface
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 
 
 
 

--- a/key_files/dic.yml
+++ b/key_files/dic.yml
@@ -15,5 +15,5 @@ model_convert   : NoChange
 
 
 layers          : Surface #50m #;100m 200m 500m 1000m 2000m
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 
 

--- a/key_files/dust.yml
+++ b/key_files/dust.yml
@@ -9,4 +9,4 @@ model_vars      : AEOLIAN
 model_convert:
     function: NoChange
 layers          : layerless
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 

--- a/key_files/iron.yml
+++ b/key_files/iron.yml
@@ -25,7 +25,7 @@ model_convert   :
 #data_convert_factor : 1000
 
 layers          : Surface #Transect ;CanRusTransect PTransect SOTransect Equator ArcTransect AntTransect ArcTransect AntTransect
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 
 
 
 

--- a/key_files/mld.yml
+++ b/key_files/mld.yml
@@ -30,6 +30,4 @@ data_convert:
     maskname : mask
     areafile: $BASEDIR_OBS/IFREMER-MLD/mld_DT02_c1m_reg2.0-annual.nc
 #layers          : Surface
-#regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
-regions         : Global OnShelf OffShelf ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthAtlanticOcean SouthAtlanticOcean NorthPacificOcean SouthPacificOcean #;Remainder NorthernSubpolarAtlantic NorthernSubpolarPacific
-
+regions         : Global OnShelf OffShelf ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthAtlanticOcean SouthAtlanticOcean NorthPacificOcean SouthPacificOcean SPNA

--- a/key_files/mpa_mld.yml
+++ b/key_files/mpa_mld.yml
@@ -30,6 +30,6 @@ data_convert:
     maskname : mask
     areafile: $BASEDIR_OBS/IFREMER-MLD/mld_DT02_c1m_reg2.0-annual.nc
 #layers          : Surface
-#regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+#regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 
 regions         : Global Ascension TristandaCunha Pitcairn Cornwall
 

--- a/key_files/nitrate.yml
+++ b/key_files/nitrate.yml
@@ -21,7 +21,7 @@ data_convert    : NoChange
 data_tdict      : ZeroToZero
 
 layers          : Surface 50m #;100m 200m 500m 1000m 2000m
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 
 
 
 

--- a/key_files/oxygen.yml
+++ b/key_files/oxygen.yml
@@ -21,5 +21,5 @@ data_convert:
     factor : 44.661
 
 layers          : Surface 100m 500m
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 
 

--- a/key_files/salinity.yml
+++ b/key_files/salinity.yml
@@ -20,4 +20,4 @@ data_convert    : NoChange
 data_tdict      : ZeroToZero
 
 layers          : Surface
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 

--- a/key_files/silicate.yml
+++ b/key_files/silicate.yml
@@ -19,7 +19,7 @@ data_convert    : NoChange
 data_tdict      : ZeroToZero
 
 layers          : Surface
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA 
 
 
 

--- a/key_files/temperature.yml
+++ b/key_files/temperature.yml
@@ -21,7 +21,7 @@ data_convert    : NoChange
 data_tdict      : ZeroToZero
 
 layers          : Surface
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean 
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA
 
 
 

--- a/key_files/temperature.yml
+++ b/key_files/temperature.yml
@@ -21,7 +21,7 @@ data_convert    : NoChange
 data_tdict      : ZeroToZero
 
 layers          : Surface
-regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA
+regions         : Global ignoreInlandSeas SouthernOcean ArcticOcean Equator10 NorthPacificOcean SouthPacificOcean NorthAtlanticOcean  SouthAtlanticOcean SPNA SPNA
 
 
 


### PR DESCRIPTION
I'm adding a new subpolar North Atlantic region (SPNA), but while doing so, I found that there's a couple inefficiencies in the data loader. 

This patch makes it much more efficient to load data as it now. Previously, if a single region or layer was missing, then all layers and regions were re-loaded. Now it checked whether the full permutation of all `(region, layers, metrics)` exists, and only loads the missing ones. 

BTW, the SPNA is 35 W to 10 W, 40N to 65N. It's an interesting region for climate change! It's going to go into all the default UKESM analyses from now. Currently testing it in Temperature.yml.

This PR requires PR #126 to be completed.


