### PR TITLE
Pin numpy <2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - matplotlib
   - nctoolkit >=0.8.7  # use linux64 build
   - netcdf4
-  - numpy >1.24.3 
+  - numpy >1.24.3,<2.0  # needs thorough checking when released
   - pip !=21.3
   - python >=3.9
   - pyyaml

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ REQUIREMENTS = {
         'matplotlib',
         'nctoolkit>=0.8.7',  # use linux64 build
         'netcdf4',
-        'numpy>1.24.3',
+        'numpy>1.24.3,<2.0',
         'pip!=21.3',
         'pyyaml',
         'scikit-learn',


### PR DESCRIPTION
numpy==2.0.0 is imminent (end of May they say, more like June). Lots of issues from testing with 2.0.0rc1 and we need to be very sure all things work both with our code and with various dependencies.