### PR TITLE
Free (unpin) numpy so we can test with the new numpy 2.0.0

### DIFF
--- a/.github/workflows/run-tests-push.yml
+++ b/.github/workflows/run-tests-push.yml
@@ -28,6 +28,8 @@ jobs:
       - shell: bash -l {0}
         run: pip install -e .[develop]
       - shell: bash -l {0}
+        run: conda list
+      - shell: bash -l {0}
         run: |
           analysis_compare --help
           analysis_level3_amoc --help
@@ -39,6 +41,6 @@ jobs:
           bgcval2_make_report --help
           download_from_mass --help 
       - shell: bash -l {0}
-        run: pytest
+        run: pytest -n 2
       - shell: bash -l {0}
         run: sphinx-build -Ea doc doc/build

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,6 +33,8 @@ jobs:
       - shell: bash -l {0}
         run: pip install -e .[develop]
       - shell: bash -l {0}
+        run: conda list
+      - shell: bash -l {0}
         run: |
           analysis_compare --help
           analysis_level3_amoc --help
@@ -45,6 +47,6 @@ jobs:
           bgcval2_make_report --help
           download_from_mass --help
       - shell: bash -l {0}
-        run: pytest
+        run: pytest -n 2
       - shell: bash -l {0}
         run: sphinx-build -Ea doc doc/build

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - matplotlib
   - nctoolkit >=0.8.7  # use linux64 build
   - netcdf4
-  - numpy >1.24.3,<2.0  # needs thorough checking when released
+  - numpy >1.24.3
   - pip !=21.3
   - python >=3.9
   - pyyaml

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ REQUIREMENTS = {
         'matplotlib',
         'nctoolkit>=0.8.7',  # use linux64 build
         'netcdf4',
-        'numpy>1.24.3,<2.0',
+        'numpy>1.24.3',
         'pip!=21.3',
         'pyyaml',
         'scikit-learn',


### PR DESCRIPTION
@ledm numpy=2.0.0 is fully out and release, it introduced a whole lot of breaking changes, so we should test with this branch; I'll have a first look at what tests break with it, then it'd be a very good idea if you took this branch and ran some of your standard analyses, see if anything breaks :beer: 