### PR TITLE
retire the use of Mambaforge

### DIFF
--- a/.github/workflows/run-tests-push.yml
+++ b/.github/workflows/run-tests-push.yml
@@ -19,7 +19,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - shell: bash -l {0}
         run: conda --version

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - shell: bash -l {0}
         run: conda --version


### PR DESCRIPTION
Mambaforge is getting sunsetted, and will be retired end of the year, so we have to retire its use; instead, this will install the latest Miniforge3, and that's what we want.