### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/run-tests-push.yml
+++ b/.github/workflows/run-tests-push.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:


### PR DESCRIPTION
We should move to support to Python 3.13 as soon as all our dependencies are built to support it; this PR tracks that, and I will include full support as soon as we have a working environment built with Python 3.13 :+1: 